### PR TITLE
[Feat] Add press in news DB + Update API.md

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -787,6 +787,65 @@ data: {"type":"vote_update","stats":{"totalVotes":101,"stats":[...]}}
 
 ---
 
+## 실시간 뉴스 (News)
+
+### 실시간 뉴스 새로고침
+`POST /news/refresh`
+
+**Response (200):**
+```json
+{
+  "success": true,
+    "data": {
+        "enqueued": 10,
+        "urls": [
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+        ]
+    }
+}
+```
+
+---
+
+### 실시간 뉴스 조회
+`GET /news/articles`
+
+**Response (200):**
+```json
+{
+  "success": true,
+    "data": [
+        {
+            "id": 20,
+            "naverUrl": "https://n.news.naver.com/mnews/article/nnn/nnnnnnnnnn",
+            "originalUrl": "크롤링한 뉴스의 원문 url",
+            "refinedTitle": "정제된 중립화 제목",
+            "refinedSummary": "정제된 중립화 본문",
+            "shortSummary": "3줄 요약 첫 번째 줄\n3줄 요약 두 번째 줄\n3줄 요약 세 번째 줄",
+            "relatedTags": [
+                "이슈 태그 1",
+                "이슈 태그 2",
+                "이슈 태그 3",
+                "이슈 태그 4"
+            ],
+            "press": "언론사",
+            "createdAt": "2024-01-01T00:00:00.000Z"
+        }, ...
+    ]
+}
+```
+
+---
+
 ## 지역 코드
 
 ```

--- a/backend/prisma/migrations/20260202092110_add_news_press/migration.sql
+++ b/backend/prisma/migrations/20260202092110_add_news_press/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "articles" ADD COLUMN     "press" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -185,6 +185,7 @@ model Article {
   refinedSummary String  
   shortSummary   String  
   relatedTags    String[]
+  press String?
 
   createdAt     DateTime @default(now())
 

--- a/backend/src/modules/news/news.route.js
+++ b/backend/src/modules/news/news.route.js
@@ -5,7 +5,7 @@ import * as newsController from './news.controller.js';
 const router = Router();
 
 const refreshLimiter = rateLimit({
-    windowMs: 1 * 60 * 1000, // 5분
+    windowMs: 1 * 60 * 1000, // 1분
     max: 1,
     message: '잠시 후 다시 시도해주세요.',
 });


### PR DESCRIPTION
## 개요
* 실시간 뉴스 크롤링에 언론사(press) 추가 + API.md 수정 + 뉴스 조회 데이터수 50개로 변경

## 주요 변경 사항

### Backend
* **[API/Controller/Service명] 수정** (`src/modules/news/news.service.js`)
   * 뉴스 크롤링 데이터에 언론사(press) 추가
   * 뉴스 조회 데이터 개수 20 -> 50으로 수정
   
### Database
* **[Model/Schema명] 수정** (`prisma/schema.prisma`)
   * Article Model에 press 추가

## 리뷰 포인트

### 1. [성능 관련]
* 크롤링 해보면서 press까지 뽑아오고 디비에 넣으니 성능이 40초대에서 5~60초대로 늘어남 이슈 
=> 그래서 일단 크롤링 뉴스 개수(concurrency)를 2에서 3으로 늘려서 현재는 30초대로 줄임.


## 테스트 체크리스트

- [x] 로컬 환경에서 정상 동작 확인
- [x] 주요 기능 테스트 완료
- [x] 에러 핸들링 확인

## PR 체크리스트

✅ **아래 규칙 한번더 확인해 주세요~!**
* commit 메시지 규칙 : `prefix: 커밋내용 요약`
  * prefix 예시: `Feat`, `Fix`, `Refactor`, `Style`, `Docs`, `Chore`
* PR 제목 규칙 : `[Prefix] 주요 변경사항 요약`

✅ **아래 항목을 충족하는지 확인해 주세요~!**
- [x] Reviewers 설정
- [x] Assignees 본인으로 설정

---

## 참고사항 
Prisma 스키마를 업데이트/마이그레이션 했기 때문에, Deploy로 DB 최신화 + Generate로 코드 최신화 해주셔야 합니다!

**Deploy : npx prisma migrate deploy**
**Generate : npx prisma generate**