### PR TITLE
[Fix] sns login + OAuth 콜백 분기 안정화 및 오류 페이지 UI 개선

### DIFF
--- a/frontend/openpoll/src/api/client.ts
+++ b/frontend/openpoll/src/api/client.ts
@@ -257,6 +257,14 @@ apiClient.interceptors.response.use(
     const originalRequest = error.config as AxiosRequestConfig & {
       _retry?: boolean;
     };
+    const requestUrl = originalRequest?.url ?? "";
+    const isOAuthCallbackRequest =
+      requestUrl.includes("/auth/oauth/") && requestUrl.includes("/callback");
+
+    // OAuth callback 401 should be handled by callback page UI, not global auth redirect.
+    if (error.response?.status === 401 && isOAuthCallbackRequest) {
+      return Promise.reject(error);
+    }
 
     // If error is 401 and we haven't retried yet
     if (error.response?.status === 401 && !originalRequest._retry) {

--- a/frontend/openpoll/src/pages/auth/OAuthCallbackPage.tsx
+++ b/frontend/openpoll/src/pages/auth/OAuthCallbackPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import type { AxiosError } from "axios";
-import { Home } from "lucide-react";
 import { authApi } from "@/api";
 import { ROUTES } from "@/shared/constants";
 import { useUser } from "@/contexts/UserContext";
@@ -26,6 +25,7 @@ export function OAuthCallbackPage() {
     phase: "loading",
     message: "소셜 로그인 처리 중입니다...",
   });
+  const [showLoadingUi, setShowLoadingUi] = useState(false);
 
   const oauthBaseUrl = import.meta.env.VITE_API_BASE_URL || "/api";
 
@@ -56,6 +56,12 @@ export function OAuthCallbackPage() {
         return;
       }
 
+      const callbackOnceKey = `oauth_callback_once:${provider}:${code}:${oauthState}`;
+      if (sessionStorage.getItem(callbackOnceKey) === "1") {
+        return;
+      }
+      sessionStorage.setItem(callbackOnceKey, "1");
+
       try {
         const data = await authApi.oauthCallback(provider, code, oauthState);
 
@@ -84,6 +90,21 @@ export function OAuthCallbackPage() {
         const message =
           axiosErr?.response?.data?.message ||
           (err instanceof Error ? err.message : "로그인 처리 중 오류가 발생했습니다.");
+        const rejoinOnceKey = `oauth_rejoin_once:${provider}:${code}:${oauthState}`;
+
+        if (
+          provider &&
+          (
+            (status === 409 && message === "REJOIN_REQUIRED") ||
+            (!status && axiosErr.message === "Network Error")
+          )
+        ) {
+          if (sessionStorage.getItem(rejoinOnceKey) !== "1") {
+            sessionStorage.setItem(rejoinOnceKey, "1");
+            startOAuth(provider, "rejoin");
+            return;
+          }
+        }
 
         if (status === 401) {
           setState({
@@ -91,16 +112,6 @@ export function OAuthCallbackPage() {
             code: 401,
             provider,
             message: "OAuth state가 유효하지 않습니다. 다시 로그인 해주세요.",
-          });
-          return;
-        }
-
-        if (status === 409 && message === "REJOIN_REQUIRED") {
-          setState({
-            phase: "error",
-            code: 409,
-            provider,
-            message: "탈퇴 이력 계정입니다. 재가입 모드로 진행해 주세요.",
           });
           return;
         }
@@ -127,10 +138,25 @@ export function OAuthCallbackPage() {
     run();
   }, [code, oauthState, provider, navigate, refreshUser]);
 
+  useEffect(() => {
+    if (state.phase !== "loading") {
+      setShowLoadingUi(false);
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setShowLoadingUi(true);
+    }, 450);
+
+    return () => window.clearTimeout(timer);
+  }, [state.phase]);
+
   if (state.phase === "loading") {
+    if (!showLoadingUi) return null;
+
     return (
       <div className="min-h-screen bg-black text-white flex items-center justify-center px-4">
-        <p className="text-gray-300 text-sm">{state.message}</p>
+        <p className="text-gray-400 text-xs">{state.message}</p>
       </div>
     );
   }
@@ -161,29 +187,11 @@ export function OAuthCallbackPage() {
             <img src={naverLogo} alt="네이버" className="w-4 h-4" />
             네이버 다시 시도
           </button>
-
-          <div className="flex items-center gap-4 pt-1">
-            <div className="h-px flex-1 bg-white/10" />
-            <span className="text-xs text-gray-500">또는</span>
-            <div className="h-px flex-1 bg-white/10" />
-          </div>
-
-          {state.code === 409 && state.provider && (
-            <button
-              type="button"
-              onClick={() => startOAuth(state.provider!, "rejoin")}
-              className="w-full h-10 rounded-lg border border-yellow-400/40 bg-yellow-500/10 hover:bg-yellow-500/15 text-sm"
-            >
-              재가입 모드로 진행
-            </button>
-          )}
-
           <button
             type="button"
             onClick={() => navigate(ROUTES.LOGIN)}
-            className="w-full h-10 rounded-lg border border-white/15 bg-white/5 hover:bg-white/10 text-sm flex items-center justify-center gap-2"
+            className="w-full h-10 rounded-lg border border-white/15 bg-white/5 hover:bg-white/10 text-sm"
           >
-            <Home className="w-4 h-4" />
             로그인 화면으로 이동
           </button>
         </div>


### PR DESCRIPTION
## 개요
* 소셜 로그인 OAuth 콜백 처리에서 중복 호출/401 전역 리다이렉트 이슈를 해결

## 주요 변경 사항

### Frontend Components
* **OAuthCallbackPage 컴포넌트 수정** (`frontend/openpoll/src/pages/auth/OAuthCallbackPage.tsx`)
   * OAuth 콜백 1회 처리 가드 추가 (`sessionStorage` 기반)
   * `REJOIN_REQUIRED(409)` 및 네트워크 에러 상황에서 재가입 모드 재시도 분기 추가
   * 로딩 UI 노출 지연(약 450ms)으로 페이지 깜빡임 완화
   * 소셜 로그인 오류 화면 UI 개선 (문구/버튼 정리, 구글/네이버 아이콘 적용)


### Layout & API
   * OAuth callback 요청의 `401`은 전역 토큰 갱신/로그인 리다이렉트로 처리하지 않고 콜백 페이지에서 직접 처리하도록 분리
   * 콜백 전용 에러 메시지/분기 흐름과 충돌하지 않도록 조정

## 리뷰 포인트

### 1. OAuth 에러 처리/보안
* OAuth callback의 `401`을 전역 리다이렉트 대신 페이지 단 처리로 분리한 방식이 적절한지
* `sessionStorage` 키 전략(`code/state/provider`)이 재진입/새로고침 케이스에서 안전한지

### 2. UX 관련
* 로딩 UI 지연(450ms)으로 인한 체감 개선이 적절한지
* 오류 페이지 버튼 구성(구글 재시도/네이버 재시도/로그인 이동)과 문구가 사용자에게 충분히 명확한지

### 3. 코드 구조/유지보수
* OAuth 예외 처리가 `OAuthCallbackPage.tsx`와 `client.ts`에 분산된 현재 구조가 유지보수에 적합한지
* 추후 백엔드 OAuth 응답 정책 변경 시 확장 가능성

## 스크린샷 (선택사항)

### OAuth 오류 화면
* 소셜 로그인 오류 화면의 타이포/버튼 구성 개선
* 재시도 버튼에 provider 아이콘(구글/네이버) 추가

### 콜백 처리
* 콜백 진입 후 빠른 분기(홈/추가입력/오류) 동작 확인 화면

## 테스트 체크리스트

- [x] 로컬 환경에서 정상 동작 확인
- [x] 주요 기능 테스트 완료 (소셜 로그인 성공/실패/재시도)
- [x] 에러 핸들링 확인 (401/400/409/Network Error)
- [x] 브라우저 콘솔 에러 없음
- [x] 콜백 중복 호출 방지 동작 확인

## PR 체크리스트

✅ **아래 규칙 한번더 확인해 주세요~!**
* commit 메시지 규칙 : `prefix: 커밋내용 요약`
  * prefix 예시: `Feat`, `Fix`, `Refactor`, `Style`, `Docs`, `Chore`
* PR 제목 규칙 : `[Prefix] 주요 변경사항 요약`

✅ **아래 항목을 충족하는지 확인해 주세요~!**
- [ ] Reviewers 설정
- [ ] Assignees 본인으로 설정
- [ ] Labels 추가 (선택사항)

---