### PR TITLE
[Modified] DOS 결과창 이미지 저장 버튼 토스트 메시지 구현 & 뉴스 프론트엔드 GET 호출 방식 전체 페이지 10분 주기 호출로 변경 & 뉴스 페이지네이션 이슈 해결

### DIFF
--- a/frontend/openpoll/src/App.tsx
+++ b/frontend/openpoll/src/App.tsx
@@ -6,6 +6,7 @@ import { LoadingSpinner } from "@/components/atoms/loadingSpinner/LoadingSpinner
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { UserProvider } from "@/contexts/UserContext";
 import { VotingProvider } from "@/contexts/VotingContext";
+import { NewsProvider } from "@/contexts/NewsContext";
 
 // Lazy load all page components
 const Home = lazy(() =>
@@ -56,39 +57,41 @@ export default function App() {
     <UserProvider>
       <ThemeProvider>
         <ErrorBoundary>
-          <Router>
-            <Suspense fallback={<LoadingSpinner />}>
-              <Routes>
-                {/* Public routes */}
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/signup" element={<SignupPage />} />
-                <Route path="/register" element={<SignupPage />} /> {/* Redirect for backward compatibility */}
-                <Route path="/auth/social-signup" element={<SocialSignupPage />} />
-                <Route path="/auth/oauth/callback" element={<OAuthCallbackPage />} />
-                <Route path="/dos/test" element={<DosTest />} />
-                <Route path="/dos/result/:type" element={<DosResult />} />
-                <Route path="/dos/share/:type" element={<DosShare />} />
-                {/* Public routes with MainLayout */}
-                <Route
-                  path="/"
-                  element={
-                    <VotingProvider>
-                      <MainLayout />
-                    </VotingProvider>
-                  }
-                >
-                  {/* All pages are now public */}
-                  <Route index element={<Home />} />
-                  <Route path="/dos" element={<DosIntro />} />
-                  <Route path="/news" element={<NewsList />} />
-                  <Route path="/news/:id" element={<NewsDetail />} />
-                  <Route path="/balance" element={<BalanceList />} />
-                  <Route path="/balance/:id" element={<BalanceDetail />} />
-                  <Route path="/profile" element={<Profile />} />
-                </Route>
-              </Routes>
-            </Suspense>
-          </Router>
+          <NewsProvider>
+            <Router>
+              <Suspense fallback={<LoadingSpinner />}>
+                <Routes>
+                  {/* Public routes */}
+                  <Route path="/login" element={<LoginPage />} />
+                  <Route path="/signup" element={<SignupPage />} />
+                  <Route path="/register" element={<SignupPage />} /> {/* Redirect for backward compatibility */}
+                  <Route path="/auth/social-signup" element={<SocialSignupPage />} />
+                  <Route path="/auth/oauth/callback" element={<OAuthCallbackPage />} />
+                  <Route path="/dos/test" element={<DosTest />} />
+                  <Route path="/dos/result/:type" element={<DosResult />} />
+                  <Route path="/dos/share/:type" element={<DosShare />} />
+                  {/* Public routes with MainLayout */}
+                  <Route
+                    path="/"
+                    element={
+                      <VotingProvider>
+                        <MainLayout />
+                      </VotingProvider>
+                    }
+                  >
+                    {/* All pages are now public */}
+                    <Route index element={<Home />} />
+                    <Route path="/dos" element={<DosIntro />} />
+                    <Route path="/news" element={<NewsList />} />
+                    <Route path="/news/:id" element={<NewsDetail />} />
+                    <Route path="/balance" element={<BalanceList />} />
+                    <Route path="/balance/:id" element={<BalanceDetail />} />
+                    <Route path="/profile" element={<Profile />} />
+                  </Route>
+                </Routes>
+              </Suspense>
+            </Router>
+          </NewsProvider>
         </ErrorBoundary>
       </ThemeProvider>
     </UserProvider>

--- a/frontend/openpoll/src/api/news.api.ts
+++ b/frontend/openpoll/src/api/news.api.ts
@@ -6,7 +6,12 @@ import type { NewsArticle, ApiResponse } from '@/types/api.types';
  * GET /news/articles
  */
 export const getArticles = async (): Promise<NewsArticle[]> => {
-    const response = await apiClient.get<ApiResponse<NewsArticle[]>>('/news/articles');
+    const response = await apiClient.get<ApiResponse<NewsArticle[]>>('/news/articles', {
+        headers: {
+            'Cache-Control': 'no-cache, no-store, must-revalidate',
+            'Pragma': 'no-cache',
+        },
+    });
     return response.data.data;
 };
 

--- a/frontend/openpoll/src/components/molecules/toast/Toast.tsx
+++ b/frontend/openpoll/src/components/molecules/toast/Toast.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type CSSProperties } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { X, AlertCircle, CheckCircle, Info } from 'lucide-react';
 
@@ -8,6 +8,7 @@ export interface ToastProps {
   isVisible: boolean;
   onClose: () => void;
   duration?: number;
+  contentStyle?: CSSProperties;
 }
 
 export function Toast({
@@ -15,7 +16,8 @@ export function Toast({
   type = 'info',
   isVisible,
   onClose,
-  duration = 3000
+  duration = 3000,
+  contentStyle
 }: ToastProps) {
   useEffect(() => {
     if (isVisible && duration > 0) {
@@ -41,28 +43,32 @@ export function Toast({
   return (
     <AnimatePresence>
       {isVisible && (
-        <motion.div
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-          initial={{ opacity: 0, y: -50 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -50 }}
-          transition={{ duration: 0.3 }}
-          className="fixed top-20 left-1/2 -translate-x-1/2 z-50 w-full max-w-md px-4"
+        <div
+          className="fixed z-50"
+          style={{ top: '5rem', left: '50%', transform: 'translateX(-50%)', width: '100%', maxWidth: '28rem', padding: '0 1rem' }}
         >
-          <div className={`flex items-center space-x-3 px-4 py-3 rounded-xl shadow-lg ${colors[type]}`}>
-            <Icon className="w-5 h-5 flex-shrink-0" aria-hidden="true" />
-            <p className="flex-1 font-semibold text-sm sm:text-base">{message}</p>
-            <button
-              onClick={onClose}
-              className="flex-shrink-0 p-1 hover:bg-white/20 rounded-lg transition-colors"
-              aria-label="알림 닫기"
-            >
-              <X className="w-4 h-4" aria-hidden="true" />
-            </button>
-          </div>
-        </motion.div>
+          <motion.div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            initial={{ opacity: 0, y: -50 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -50 }}
+            transition={{ duration: 0.3 }}
+          >
+            <div className={`flex items-center space-x-3 px-4 py-3 rounded-xl shadow-lg ${contentStyle ? '' : colors[type]}`} style={contentStyle}>
+              <Icon className="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+              <p className="flex-1 font-semibold text-sm sm:text-base">{message}</p>
+              <button
+                onClick={onClose}
+                className="flex-shrink-0 p-1 hover:bg-white/20 rounded-lg transition-colors"
+                aria-label="알림 닫기"
+              >
+                <X className="w-4 h-4" aria-hidden="true" />
+              </button>
+            </div>
+          </motion.div>
+        </div>
       )}
     </AnimatePresence>
   );

--- a/frontend/openpoll/src/contexts/NewsContext.tsx
+++ b/frontend/openpoll/src/contexts/NewsContext.tsx
@@ -1,0 +1,73 @@
+import {
+    createContext,
+    useContext,
+    useState,
+    useEffect,
+    useCallback,
+    type ReactNode,
+} from "react";
+import { newsApi } from "@/api";
+import type { NewsArticle } from "@/types/api.types";
+
+const POLLING_INTERVAL_MS = 10 * 60 * 1000; // 10분
+
+interface NewsContextValue {
+    articles: NewsArticle[];
+    isLoading: boolean;
+    error: string | null;
+    fetchedAt: Date | null;
+}
+
+const NewsContext = createContext<NewsContextValue>({
+    articles: [],
+    isLoading: true,
+    error: null,
+    fetchedAt: null,
+});
+
+export function NewsProvider({ children }: { children: ReactNode }) {
+    const [articles, setArticles] = useState<NewsArticle[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [fetchedAt, setFetchedAt] = useState<Date | null>(null);
+
+    const fetchArticles = useCallback(async (showLoading = false) => {
+        try {
+            if (showLoading) setIsLoading(true);
+            console.log("[NewsContext] 뉴스 데이터 fetch 시작", new Date().toLocaleTimeString());
+            const data = await newsApi.getArticles();
+            console.log("[NewsContext] 뉴스 데이터 fetch 완료, 기사 수:", data.length, "| 첫 기사:", data[0]?.refinedTitle?.slice(0, 30));
+            setArticles(data);
+            setFetchedAt(new Date());
+            setError(null);
+        } catch {
+            console.error("[NewsContext] 뉴스 데이터 fetch 실패");
+            setError("뉴스를 불러오는데 실패했습니다.");
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        // 최초 로드
+        fetchArticles(true);
+
+        // 10분 간격 폴링
+        const intervalId = setInterval(() => {
+            fetchArticles(false);
+        }, POLLING_INTERVAL_MS);
+
+        return () => clearInterval(intervalId);
+    }, [fetchArticles]);
+
+    return (
+        <NewsContext.Provider value={{ articles, isLoading, error, fetchedAt }}>
+            {children}
+        </NewsContext.Provider>
+    );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useNewsContext(): NewsContextValue {
+    return useContext(NewsContext);
+}

--- a/frontend/openpoll/src/pages/dos/DosResult.tsx
+++ b/frontend/openpoll/src/pages/dos/DosResult.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { usePageMeta } from "@/hooks/usePageMeta";
 import type { DosResult as DosResultData } from "@/types/api.types";
@@ -16,6 +16,7 @@ import {
   NavigationLinks,
 } from "./components";
 import { ShareModal } from "./components/ShareModal";
+import { Toast } from "@/components/molecules/toast/Toast";
 
 export function DosResult() {
   usePageMeta("DOS 테스트 결과", "나의 정치 성향 분석 결과를 확인하세요.");
@@ -23,6 +24,11 @@ export function DosResult() {
   const location = useLocation();
   const navigate = useNavigate();
   const [showShareModal, setShowShareModal] = useState(false);
+  const [showToast, setShowToast] = useState(false);
+
+  const handleImageSave = useCallback(() => {
+    setShowToast(true);
+  }, []);
 
   const { resultTypeInfo, isLoading } = useResultData(type, navigate);
 
@@ -62,7 +68,7 @@ export function DosResult() {
         <DescriptionSection detail={detail} />
         <CharacteristicsSection features={features} tags={tags} />
         <NoticeSection />
-        <ActionButtons onShare={() => setShowShareModal(true)} />
+        <ActionButtons onShare={() => setShowShareModal(true)} onImageSave={handleImageSave} />
         <NavigationLinks />
       </div>
 
@@ -70,6 +76,14 @@ export function DosResult() {
         isOpen={showShareModal}
         onClose={() => setShowShareModal(false)}
         type={type || ""}
+      />
+
+      <Toast
+        message="추후 구현될 기능입니다!"
+        type="info"
+        isVisible={showToast}
+        onClose={() => setShowToast(false)}
+        contentStyle={{ backgroundColor: '#ffffff', color: '#1a1a1a' }}
       />
     </div>
   );

--- a/frontend/openpoll/src/pages/dos/components/DosResultComponents.tsx
+++ b/frontend/openpoll/src/pages/dos/components/DosResultComponents.tsx
@@ -288,9 +288,10 @@ export function NoticeSection() {
 
 interface ActionButtonsProps {
   onShare?: () => void;
+  onImageSave?: () => void;
 }
 
-export function ActionButtons({ onShare }: ActionButtonsProps) {
+export function ActionButtons({ onShare, onImageSave }: ActionButtonsProps) {
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -305,7 +306,10 @@ export function ActionButtons({ onShare }: ActionButtonsProps) {
         <Share2 className="w-4 h-4 sm:w-5 sm:h-5" />
         <span>결과 공유하기</span>
       </button>
-      <button className="flex items-center justify-center space-x-2 px-6 py-3 sm:py-4 bg-white/10 border border-white/20 rounded-xl font-semibold text-sm sm:text-base hover:bg-white/20 transition-colors">
+      <button
+        onClick={onImageSave}
+        className="flex items-center justify-center space-x-2 px-6 py-3 sm:py-4 bg-white/10 border border-white/20 rounded-xl font-semibold text-sm sm:text-base hover:bg-white/20 transition-colors"
+      >
         <Download className="w-4 h-4 sm:w-5 sm:h-5" />
         <span>이미지 저장</span>
       </button>

--- a/frontend/openpoll/src/pages/dos/components/ShareModal.tsx
+++ b/frontend/openpoll/src/pages/dos/components/ShareModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
+import { useState, useRef, useCallback, type ReactNode } from "react";
 import { X, Link2, Check, Copy, QrCode } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { QRCodeSVG } from "qrcode.react";
@@ -44,9 +44,7 @@ const EmailIcon = () => (
 );
 
 const SHARE_TEXT = "나의 DOS 정치 성향 결과를 확인해보세요!";
-const SHARE_SUBJECT = "나의 DOS 정치 성향 결과";
 const COPY_RESET_MS = 2500;
-const EMAIL_COOLDOWN_MS = 5000;
 const POPUP_OPTIONS = "width=550,height=420";
 
 const ICON_BASE_CLASS =
@@ -63,12 +61,11 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
     const shareUrl = `${window.location.origin}/dos/share/${type}`;
 
     // Reset states when modal closes
-    useEffect(() => {
-        if (!isOpen) {
-            setCopied(false);
-            setEmailCopied(false);
-        }
-    }, [isOpen]);
+    const handleClose = useCallback(() => {
+        setCopied(false);
+        setEmailCopied(false);
+        onClose();
+    }, [onClose]);
 
     const handleCopy = useCallback(async () => {
         try {
@@ -149,7 +146,7 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
                     exit={{ opacity: 0 }}
                     transition={{ duration: 0.2 }}
                     className="fixed inset-0 z-50 flex items-center justify-center px-8"
-                    onClick={onClose}
+                    onClick={handleClose}
                 >
                     {/* Backdrop */}
                     <div className="absolute inset-0 bg-black/50" style={{ backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)' }} />
@@ -175,7 +172,7 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
                                 </div>
                             </div>
                             <button
-                                onClick={onClose}
+                                onClick={handleClose}
                                 className="p-2 rounded-lg hover:bg-white/10 transition-colors"
                             >
                                 <X className="w-5 h-5 text-white" />
@@ -291,7 +288,7 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
 
                         <div className="p-5 border-t border-white/10 flex justify-end">
                             <button
-                                onClick={onClose}
+                                onClick={handleClose}
                                 className="px-4 py-2 rounded-lg border border-white/10 text-gray-300 hover:text-white hover:border-white/20 transition-colors"
                             >
                                 닫기

--- a/frontend/openpoll/src/pages/news/NewsList.tsx
+++ b/frontend/openpoll/src/pages/news/NewsList.tsx
@@ -31,7 +31,7 @@ export function NewsList() {
   if (error) return <NewsListErrorState message={error} />;
 
   return (
-    <div className="pt-16 min-h-screen bg-gray-50 dark:bg-gray-950">
+    <div className="pt-16 pb-24 sm:pb-0 min-h-screen bg-gray-50 dark:bg-gray-950">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
         <motion.div
           initial={{ opacity: 0, y: -20 }}
@@ -62,8 +62,8 @@ export function NewsList() {
               key={category}
               onClick={() => handleCategoryChange(category)}
               className={`flex-shrink-0 px-6 py-3 rounded-full font-bold text-base transition-all ${selectedCategory === category
-                  ? "bg-black text-white dark:bg-white dark:text-black shadow-lg"
-                  : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-500"
+                ? "bg-black text-white dark:bg-white dark:text-black shadow-lg"
+                : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-500"
                 }`}
             >
               {category}

--- a/frontend/openpoll/src/pages/news/components/NewsCard.tsx
+++ b/frontend/openpoll/src/pages/news/components/NewsCard.tsx
@@ -56,8 +56,8 @@ export function NewsCard({ news, index, category }: NewsCardProps) {
 
           <div className="space-y-3 mb-6 sm:mb-7">
             {summaryLines.map((line, i) => (
-              <div key={i} className="flex items-start text-base text-gray-700 dark:text-gray-300">
-                <span className="text-gray-400 dark:text-gray-600 font-bold text-lg mr-4">
+              <div key={i} className="flex items-start gap-3 text-base text-gray-700 dark:text-gray-300">
+                <span className="text-gray-400 dark:text-gray-600 font-bold text-lg flex-shrink-0" style={{ lineHeight: '1.625' }}>
                   ·
                 </span>
                 <span className="leading-relaxed">{line}</span>

--- a/frontend/openpoll/src/pages/news/hooks/index.ts
+++ b/frontend/openpoll/src/pages/news/hooks/index.ts
@@ -1,5 +1,5 @@
-export { useNewsList, useNewsArticles, useTimeAgo } from "./useNewsList";
-export type { UseNewsListReturn, UseNewsArticlesReturn, ArticleWithCategory } from "./useNewsList";
+export { useNewsList, useTimeAgo } from "./useNewsList";
+export type { UseNewsListReturn, ArticleWithCategory } from "./useNewsList";
 
 export { useArticleDetail } from "./useNewsDetail";
 export type { UseArticleDetailReturn } from "./useNewsDetail";

--- a/frontend/openpoll/src/pages/news/hooks/useNewsDetail.ts
+++ b/frontend/openpoll/src/pages/news/hooks/useNewsDetail.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { newsApi } from "@/api";
+import { useMemo } from "react";
+import { useNewsContext } from "@/contexts/NewsContext";
 import type { NewsArticle } from "@/types/api.types";
 
 export interface UseArticleDetailReturn {
@@ -9,36 +9,19 @@ export interface UseArticleDetailReturn {
 }
 
 export function useArticleDetail(id: string | undefined): UseArticleDetailReturn {
-  const [article, setArticle] = useState<NewsArticle | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { articles, isLoading, error } = useNewsContext();
 
-  useEffect(() => {
-    const fetchArticle = async () => {
-      if (!id) {
-        setError("잘못된 접근입니다.");
-        setIsLoading(false);
-        return;
-      }
+  const article = useMemo(() => {
+    if (!id || articles.length === 0) return null;
+    return articles.find((a) => a.id === parseInt(id)) || null;
+  }, [id, articles]);
 
-      try {
-        setIsLoading(true);
-        const data = await newsApi.getArticleById(parseInt(id));
-        if (data) {
-          setArticle(data);
-          setError(null);
-        } else {
-          setError("뉴스를 찾을 수 없습니다.");
-        }
-      } catch {
-        setError("뉴스를 불러오는데 실패했습니다.");
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const detailError = useMemo(() => {
+    if (error) return error;
+    if (!id) return "잘못된 접근입니다.";
+    if (!isLoading && articles.length > 0 && !article) return "뉴스를 찾을 수 없습니다.";
+    return null;
+  }, [id, error, isLoading, articles, article]);
 
-    fetchArticle();
-  }, [id]);
-
-  return { article, isLoading, error };
+  return { article, isLoading, error: detailError };
 }

--- a/frontend/openpoll/src/pages/news/hooks/useNewsList.ts
+++ b/frontend/openpoll/src/pages/news/hooks/useNewsList.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { newsApi } from "@/api";
 import type { NewsArticle } from "@/types/api.types";
+import { useNewsContext } from "@/contexts/NewsContext";
 import {
   ITEMS_PER_PAGE,
   getCategoryFromTags,
@@ -10,64 +10,25 @@ export interface ArticleWithCategory extends NewsArticle {
   category: string;
 }
 
-export interface UseNewsArticlesReturn {
-  articles: NewsArticle[];
-  isLoading: boolean;
-  error: string | null;
-  fetchedAt: Date | null;
-}
-
-export function useNewsArticles(): UseNewsArticlesReturn {
-  const [articles, setArticles] = useState<NewsArticle[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [fetchedAt, setFetchedAt] = useState<Date | null>(null);
-
-  const fetchArticles = useCallback(async () => {
-    try {
-      const data = await newsApi.getArticles();
-      setArticles(data);
-      setFetchedAt(new Date());
-      setError(null);
-    } catch {
-      setError("뉴스를 불러오는데 실패했습니다.");
-    }
-  }, []);
-
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
-
-  useEffect(() => {
-    const initialFetch = async () => {
-      setIsLoading(true);
-      await fetchArticles();
-      setIsLoading(false);
-    };
-    initialFetch();
-  }, [fetchArticles]);
-
-  return { articles, isLoading, error, fetchedAt };
-}
-
 /** fetchedAt으로부터 상대 시간 문자열을 계산하고 30초마다 갱신 */
 export function useTimeAgo(date: Date | null): string {
-  const [, setTick] = useState(0);
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
     if (!date) return;
-    const id = setInterval(() => setTick((t) => t + 1), 30_000);
+    const id = setInterval(() => setNow(Date.now()), 30_000);
     return () => clearInterval(id);
   }, [date]);
 
-  if (!date) return "";
-
-  const diffSec = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (diffSec < 60) return "방금 업데이트";
-  const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}분 전 업데이트`;
-  const diffHr = Math.floor(diffMin / 60);
-  return `${diffHr}시간 전 업데이트`;
+  return useMemo(() => {
+    if (!date) return "";
+    const diffSec = Math.floor((now - date.getTime()) / 1000);
+    if (diffSec < 60) return "방금 업데이트";
+    const diffMin = Math.floor(diffSec / 60);
+    if (diffMin < 60) return `${diffMin}분 전 업데이트`;
+    const diffHr = Math.floor(diffMin / 60);
+    return `${diffHr}시간 전 업데이트`;
+  }, [date, now]);
 }
 
 export interface UseNewsListReturn {
@@ -85,7 +46,11 @@ export interface UseNewsListReturn {
 export function useNewsList(): UseNewsListReturn {
   const [selectedCategory, setSelectedCategory] = useState("전체");
   const [currentPage, setCurrentPage] = useState(1);
-  const { articles, isLoading, error, fetchedAt } = useNewsArticles();
+  const { articles, isLoading, error, fetchedAt } = useNewsContext();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   const articlesWithCategory = useMemo<ArticleWithCategory[]>(
     () =>


### PR DESCRIPTION
## 개요
* DOS 결과 페이지의 이미지 저장 토스트 기능 구현 및 뉴스 데이터 fetching 로직을 10분 주기 전역 폴링 방식으로 리팩토링
* DOS/News 관련 코드 린트 에러 수정 및 코드 품질 개선

## 주요 변경 사항

### Frontend Components
* **Toast 컴포넌트 수정** 
   * `contentStyle` prop 추가로 커스텀 스타일링 지원
   * 인라인 스타일 기반으로 포지셔닝 변경 (Tailwind CSS 누락 이슈 해결)

* **ActionButtons 컴포넌트 수정** 
   * `onImageSave` prop 추가 및 이미지 저장 버튼 onClick 핸들러 연결

* **DosResult 페이지 수정** 
   * 이미지 저장 버튼 클릭 시 토스트 메시지 표시 기능 추가
   * Toast 컴포넌트 렌더링 및 상태 관리 로직 구현

* **ShareModal 컴포넌트 리팩토링** 
   * 미사용 상수 `SHARE_SUBJECT`, `EMAIL_COOLDOWN_MS` 제거
   * `useEffect` 기반 상태 초기화를 `handleClose` 콜백 방식으로 변경 (cascading render 방지)
   * 미사용 `useEffect` import 제거

* **NewsCard 컴포넌트 수정** 
   * 세 줄 요약 bullet(·)과 텍스트 사이 간격 조정 (`gap-3`, `flex-shrink-0`)
   * 피그마 디자인과 일치하도록 bullet 라인 높이 보정

* **NewsList 페이지 수정** 
   * 모바일 하단 네비게이션 바에 가려지던 페이지네이션 UI 수정 (`pb-24 sm:pb-0`)

### State Management
* **NewsContext 추가** 
   * [NewsProvider]: 앱 전역 뉴스 데이터 상태 관리
   * 마운트 시 즉시 fetch + 10분 간격 자동 폴링 (setInterval)
   * [useNewsContext()]: articles, isLoading, error, fetchedAt 제공

### Hooks
* **useNewsList 훅 리팩토링** 
   * `useNewsArticles` 훅 삭제 → [useNewsContext()] 기반으로 변경
   * [useTimeAgo] 훅: `Date.now()` 렌더 중 직접 호출 제거 → `useState` + `useMemo` 기반 순수 함수로 리팩토링

* **useNewsDetail 훅 리팩토링** 
   * 개별 API 호출([getArticleById] 제거 → [useNewsContext()] 에서 articles 가져와 ID로 필터

* **hooks/index.ts 수정** 
   * 삭제된 `useNewsArticles`, `UseNewsArticlesReturn` export 제거

### API
* **News API 수정** 
   * [getArticles] 요청에 `Cache-Control: no-cache, no-store` 헤더 추가 (브라우저 캐시 방지)

### Layout
* **App.tsx 수정** 
   * [NewsProvider] 를 `Router` 상위에 추가하여 모든 라우트에서 전역 뉴스 상태 접근 가능

## 리뷰 포인트

### 1. 뉴스 폴링 아키텍처
* [NewsContext] 가 앱 최상위에서 10분마다 자동 폴링 → 페이지 진입 시 별도 API 호출 없이 캐시된 데이터 즉시 표시
* `useNewsDetail`이 이제 개별 API 호출 대신 Context의 articles 배열에서 필터링하므로, 혹시 articles에 없는 ID 접근 시 에러 처리가 적절한지 확인 필요

### 2. UX 관련
* 모바일 뉴스 리스트 하단 패딩(`pb-24`)이 다양한 기기에서 네비게이션 바 높이와 적절히 맞는지 확인 필요
* 세 줄 요약 bullet 간격이 피그마 디자인과 일치하는지 시각적 검토 필요

### 3. 코드 품질
* [ShareModal]의 `handleClose` 콜백 변경이 기존 모달 닫기 동작(배경 클릭, X 버튼, 닫기 버튼)과 동일하게 작동하는지 확인
* [NewsContext]에 디버그용 `console.log`가 남아있음 — 머지 전 제거 필요

## 테스트 체크리스트

- [ ] 로컬 환경에서 정상 동작 확인
- [ ] DOS 결과 페이지 이미지 저장 버튼 클릭 시 토스트 표시 확인
- [ ] DOS 공유 모달 정상 열림/닫힘 및 상태 초기화 확인
- [ ] 뉴스 리스트 진입 시 데이터 즉시 표시 확인
- [ ] 뉴스 상세 페이지 진입 시 별도 API 호출 없이 데이터 표시 확인
- [ ] 뉴스 리스트 "X분 전 업데이트" 시간 표시 정상 갱신 확인
- [ ] 모바일 뉴스 리스트 페이지네이션 UI 네비게이션 바에 가려지지 않는지 확인
- [ ] ESLint / TypeScript 에러 없음 확인
- [ ] 브라우저 콘솔 에러 없음

## PR 체크리스트

✅ **아래 규칙 한번더 확인해 주세요~!**
* commit 메시지 규칙 : `prefix: 커밋내용 요약`
  * prefix 예시: `Feat`, `Fix`, `Refactor`, `Style`, `Docs`, `Chore`
* PR 제목 규칙 : `[Prefix] 주요 변경사항 요약`

✅ **아래 항목을 충족하는지 확인해 주세요~!**
- [ ] Reviewers 설정
- [ ] Assignees 본인으로 설정
- [ ] Labels 추가 (선택사항)

---

## 참고사항
* [NewsContext](cci:1://file:///Users/jaewoo/Desktop/OpenPoll/OpenPoll/frontend/openpoll/src/contexts/NewsContext.tsx:69:0-72:1)의 디버그용 `console.log` 3줄은 테스트 완료 후 제거 필요
* 뉴스 폴링 주기는 현재 `10분`으로 설정되어 있으며, 백엔드 크롤링 주기와 동일