### PR TITLE
[Fix] social oauth callback and signup flow

### DIFF
--- a/frontend/openpoll/src/App.tsx
+++ b/frontend/openpoll/src/App.tsx
@@ -1,5 +1,13 @@
 import { lazy, Suspense } from "react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import type { ReactNode } from "react";
+import {
+  BrowserRouter as Router,
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigationType,
+} from "react-router-dom";
 import { MainLayout } from "@/components/templates";
 import { ErrorBoundary } from "@/components/templates/errorBoundary/ErrorBoundary";
 import { LoadingSpinner } from "@/components/atoms/loadingSpinner/LoadingSpinner";
@@ -7,6 +15,7 @@ import { ThemeProvider } from "@/contexts/ThemeContext";
 import { UserProvider } from "@/contexts/UserContext";
 import { VotingProvider } from "@/contexts/VotingContext";
 import { NewsProvider } from "@/contexts/NewsContext";
+import { ROUTES } from "@/shared/constants";
 
 // Lazy load all page components
 const Home = lazy(() =>
@@ -51,6 +60,37 @@ const OAuthCallbackPage = lazy(() =>
 const Profile = lazy(() =>
   import("@/pages/profile").then((m) => ({ default: m.Profile })),
 );
+const SOCIAL_PROFILE_PENDING_KEY = "social_profile_pending";
+
+function clearSocialPendingSession() {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+  localStorage.removeItem("openpoll_session_v1");
+  localStorage.removeItem(SOCIAL_PROFILE_PENDING_KEY);
+  localStorage.removeItem("oauthProvider");
+  window.dispatchEvent(new Event("storage"));
+}
+
+function SocialProfilePendingGuard({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  const isPending = localStorage.getItem(SOCIAL_PROFILE_PENDING_KEY) === "1";
+
+  if (!isPending) return <>{children}</>;
+
+  const allowPaths = [ROUTES.SOCIAL_SIGNUP] as const;
+  if (allowPaths.includes(location.pathname as (typeof allowPaths)[number])) {
+    return <>{children}</>;
+  }
+
+  // 뒤로가기(POP)로 이탈하면 가입 플로우를 취소하고 홈으로 보냄
+  if (navigationType === "POP") {
+    clearSocialPendingSession();
+    return <Navigate to={ROUTES.HOME} replace />;
+  }
+
+  return <Navigate to={ROUTES.SOCIAL_SIGNUP} replace />;
+}
 
 export default function App() {
   return (
@@ -60,35 +100,37 @@ export default function App() {
           <NewsProvider>
             <Router>
               <Suspense fallback={<LoadingSpinner />}>
-                <Routes>
-                  {/* Public routes */}
-                  <Route path="/login" element={<LoginPage />} />
-                  <Route path="/signup" element={<SignupPage />} />
-                  <Route path="/register" element={<SignupPage />} /> {/* Redirect for backward compatibility */}
-                  <Route path="/auth/social-signup" element={<SocialSignupPage />} />
-                  <Route path="/auth/oauth/callback" element={<OAuthCallbackPage />} />
-                  <Route path="/dos/test" element={<DosTest />} />
-                  <Route path="/dos/result/:type" element={<DosResult />} />
-                  <Route path="/dos/share/:type" element={<DosShare />} />
-                  {/* Public routes with MainLayout */}
-                  <Route
-                    path="/"
-                    element={
-                      <VotingProvider>
-                        <MainLayout />
-                      </VotingProvider>
-                    }
-                  >
-                    {/* All pages are now public */}
-                    <Route index element={<Home />} />
-                    <Route path="/dos" element={<DosIntro />} />
-                    <Route path="/news" element={<NewsList />} />
-                    <Route path="/news/:id" element={<NewsDetail />} />
-                    <Route path="/balance" element={<BalanceList />} />
-                    <Route path="/balance/:id" element={<BalanceDetail />} />
-                    <Route path="/profile" element={<Profile />} />
-                  </Route>
-                </Routes>
+                <SocialProfilePendingGuard>
+                  <Routes>
+                    {/* Public routes */}
+                    <Route path="/login" element={<LoginPage />} />
+                    <Route path="/signup" element={<SignupPage />} />
+                    <Route path="/register" element={<SignupPage />} /> {/* Redirect for backward compatibility */}
+                    <Route path="/auth/social-signup" element={<SocialSignupPage />} />
+                    <Route path="/auth/oauth/callback" element={<OAuthCallbackPage />} />
+                    <Route path="/dos/test" element={<DosTest />} />
+                    <Route path="/dos/result/:type" element={<DosResult />} />
+                    <Route path="/dos/share/:type" element={<DosShare />} />
+                    {/* Public routes with MainLayout */}
+                    <Route
+                      path="/"
+                      element={
+                        <VotingProvider>
+                          <MainLayout />
+                        </VotingProvider>
+                      }
+                    >
+                      {/* All pages are now public */}
+                      <Route index element={<Home />} />
+                      <Route path="/dos" element={<DosIntro />} />
+                      <Route path="/news" element={<NewsList />} />
+                      <Route path="/news/:id" element={<NewsDetail />} />
+                      <Route path="/balance" element={<BalanceList />} />
+                      <Route path="/balance/:id" element={<BalanceDetail />} />
+                      <Route path="/profile" element={<Profile />} />
+                    </Route>
+                  </Routes>
+                </SocialProfilePendingGuard>
               </Suspense>
             </Router>
           </NewsProvider>

--- a/frontend/openpoll/src/contexts/UserContext.tsx
+++ b/frontend/openpoll/src/contexts/UserContext.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/api/client";
 import type { AxiosError } from "axios";
 import type { User, AuthResponse } from "@/types/api.types";
+const SOCIAL_PROFILE_PENDING_KEY = "social_profile_pending";
 
 interface UserContextType {
   user: User | null;
@@ -52,6 +53,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
       // 토큰이 없으면 로그인 필요
       if (!accessToken && !refreshToken) {
+        localStorage.removeItem(SOCIAL_PROFILE_PENDING_KEY);
         setIsLoading(false);
         return;
       }
@@ -167,6 +169,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
       // Save tokens
       localStorage.setItem("accessToken", response.accessToken);
       localStorage.setItem("refreshToken", response.refreshToken);
+      localStorage.removeItem(SOCIAL_PROFILE_PENDING_KEY);
 
       // Set user
       setUser(response.user);
@@ -210,6 +213,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         // Save tokens
         localStorage.setItem("accessToken", response.accessToken);
         localStorage.setItem("refreshToken", response.refreshToken);
+        localStorage.removeItem(SOCIAL_PROFILE_PENDING_KEY);
 
         // Set user
         setUser(response.user);
@@ -251,6 +255,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
       // Clear localAuth session
       localStorage.removeItem("openpoll_session_v1");
+      localStorage.removeItem(SOCIAL_PROFILE_PENDING_KEY);
       window.dispatchEvent(new Event("storage"));
     }
   }, []);

--- a/frontend/openpoll/src/pages/auth/OAuthCallbackPage.tsx
+++ b/frontend/openpoll/src/pages/auth/OAuthCallbackPage.tsx
@@ -8,6 +8,7 @@ import googleLogo from "@/img/google-logo.svg";
 import naverLogo from "@/img/naver-logo.svg";
 
 type OAuthProvider = "google" | "naver";
+const SOCIAL_PROFILE_PENDING_KEY = "social_profile_pending";
 
 type CallbackState =
   | { phase: "loading"; message: string }
@@ -80,9 +81,11 @@ export function OAuthCallbackPage() {
         await refreshUser();
 
         if (!data.profileComplete) {
+          localStorage.setItem(SOCIAL_PROFILE_PENDING_KEY, "1");
           navigate(ROUTES.SOCIAL_SIGNUP, { replace: true });
           return;
         }
+        localStorage.removeItem(SOCIAL_PROFILE_PENDING_KEY);
         navigate(ROUTES.HOME, { replace: true });
       } catch (err) {
         const axiosErr = err as AxiosError<{ message?: string }>;

--- a/frontend/openpoll/src/pages/auth/SocialSignup.tsx
+++ b/frontend/openpoll/src/pages/auth/SocialSignup.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { User, Calendar, Users, MapPin } from "lucide-react";
 import { motion } from "motion/react";
@@ -12,6 +12,7 @@ type SocialSignupErrors = {
   gender?: string;
   region?: string;
 };
+const SOCIAL_PROFILE_PENDING_KEY = "social_profile_pending";
 
 export function SocialSignup() {
   const navigate = useNavigate();
@@ -26,6 +27,34 @@ export function SocialSignup() {
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const cancelPendingSignup = () => {
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+    localStorage.removeItem("openpoll_session_v1");
+    localStorage.removeItem(SOCIAL_PROFILE_PENDING_KEY);
+    localStorage.removeItem("oauthProvider");
+    window.dispatchEvent(new Event("storage"));
+    window.location.replace(ROUTES.HOME);
+  };
+
+  useEffect(() => {
+    const isPending = localStorage.getItem(SOCIAL_PROFILE_PENDING_KEY) === "1";
+    if (!isPending) {
+      navigate(ROUTES.HOME, { replace: true });
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    window.history.pushState({ socialSignupTrap: true }, "", window.location.href);
+    const onPopState = () => {
+      cancelPendingSignup();
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => {
+      window.removeEventListener("popstate", onPopState);
+    };
+  }, []);
 
   const validate = () => {
     const next: SocialSignupErrors = {};
@@ -86,6 +115,7 @@ export function SocialSignup() {
         window.dispatchEvent(new Event("storage"));
       }
 
+      localStorage.removeItem(SOCIAL_PROFILE_PENDING_KEY);
       await refreshUser();
       navigate(ROUTES.HOME);
     } catch (err) {


### PR DESCRIPTION
## 개요
* 소셜 로그인 후 `추가정보 입력` 미완료 상태에서 뒤로가기로 이탈하면 로그인 상태가 유지되던 문제를 수정했습니다.
* 미완료 상태를 플래그로 관리하고, 라우트 가드/페이지 레벨 처리로 가입 완료 전 이탈을 통제했습니다.

## 주요 변경 사항

### Frontend Components
* **OAuthCallbackPage 수정** (`frontend/openpoll/src/pages/auth/OAuthCallbackPage.tsx`)
   * OAuth 성공 후 `profileComplete=false`일 때 `social_profile_pending` 플래그 저장
   * 가입 완료(`profileComplete=true`) 시 pending 플래그 제거

* **SocialSignup 수정** (`frontend/openpoll/src/pages/auth/SocialSignup.tsx`)
   * 뒤로가기(`popstate`) 시 가입 취소 처리(토큰/세션 제거 + 홈 이동)
   * 가입 완료 시 pending 플래그 제거 후 정상 로그인 상태 전환


### Layout & API
* **App 라우팅 가드 추가/수정** (`frontend/openpoll/src/App.tsx`)
   * `SocialProfilePendingGuard`로 미완료 상태 라우트 이탈 제어
   * POP 네비게이션(뒤로가기) 시 가입 취소 흐름으로 보정



## 스크린샷 (선택사항)

### 소셜 추가정보 입력 페이지
* 뒤로가기 시 가입 취소 동작 확인

### OAuth 콜백 분기
* `profileComplete=false` -> `SOCIAL_SIGNUP` 이동
* `profileComplete=true` -> 홈 이동

