### PR TITLE
[Fix] 밸런스 HOT 배지 Top3 노출 및 로그인 보상 문구 정합성 수정

### DIFF
--- a/frontend/openpoll/src/pages/auth/Login.tsx
+++ b/frontend/openpoll/src/pages/auth/Login.tsx
@@ -155,7 +155,7 @@ export function Login() {
 
             <div className="w-full h-14 rounded-2xl border border-green-500/25 bg-green-500/10 shadow-[0_0_40px_rgba(34,197,94,0.15)] flex items-center justify-center gap-2 font-semibold">
               <Gift className="w-5 h-5 text-green-400" />
-              <span className="text-green-400">로그인 시 500P 지급!</span>
+              <span className="text-green-400">회원가입 시 500P 지급!</span>
             </div>
 
             <p className="text-center text-sm text-gray-400">

--- a/frontend/openpoll/src/pages/balance/BalanceList.tsx
+++ b/frontend/openpoll/src/pages/balance/BalanceList.tsx
@@ -30,6 +30,7 @@ export function BalanceList() {
     isLoading,
     errorMessage,
     filteredIssues,
+    hotRankMap,
     isModalOpen,
     setIsModalOpen,
     modalMode,
@@ -163,6 +164,7 @@ export function BalanceList() {
                 >
                   <BalanceGameCard
                     issue={issue}
+                    hotRank={hotRankMap[issue.id] ?? null}
                     isLoggedIn={isLoggedIn}
                     isAdmin={isAdmin}
                     hideAdminActions={hideAdminActions}

--- a/frontend/openpoll/src/pages/balance/components/BalanceGameCard.tsx
+++ b/frontend/openpoll/src/pages/balance/components/BalanceGameCard.tsx
@@ -16,6 +16,7 @@ import type {
 
 interface BalanceGameCardProps {
   issue: BalanceListItem;
+  hotRank: number | null;
   isLoggedIn: boolean;
   isAdmin: boolean;
   hideAdminActions: boolean;
@@ -25,6 +26,7 @@ interface BalanceGameCardProps {
 
 export function BalanceGameCard({
   issue,
+  hotRank,
   isLoggedIn,
   isAdmin,
   hideAdminActions,
@@ -43,7 +45,7 @@ export function BalanceGameCard({
   const disagreePercentSafe =
     participantsSafe <= 0 ? 0 : Math.max(0, 100 - agreePercentSafe);
 
-  const isHotIssue = participantsSafe >= 3000;
+  const isHotIssue = hotRank !== null && hotRank <= 3;
   const showCompleted =
     isLoggedIn && (Boolean(issueEx.voted) || issue.myVote !== null);
 

--- a/frontend/openpoll/src/pages/balance/hooks/useBalanceList.ts
+++ b/frontend/openpoll/src/pages/balance/hooks/useBalanceList.ts
@@ -94,6 +94,19 @@ export function useBalanceList(isLoggedIn: boolean) {
     });
   }, [issues, filter, isLoggedIn]);
 
+  const hotRankMap = useMemo(() => {
+    const ranked = [...issues].sort((a, b) => {
+      const ap = Number(a.participants ?? a.totalVotes ?? 0);
+      const bp = Number(b.participants ?? b.totalVotes ?? 0);
+      return bp - ap;
+    });
+
+    return ranked.reduce<Record<number, number>>((acc, item, index) => {
+      acc[item.id] = index + 1;
+      return acc;
+    }, {});
+  }, [issues]);
+
   const openCreate = () => {
     setErrorMessage(null);
     setModalMode("create");
@@ -178,6 +191,7 @@ export function useBalanceList(isLoggedIn: boolean) {
     isLoading,
     errorMessage,
     filteredIssues,
+    hotRankMap,
     isModalOpen,
     setIsModalOpen,
     modalMode,


### PR DESCRIPTION
## 개요
* 밸런스게임의 HOT 배지 조건을 `Top 3` 기준으로 변경하고, `핫이슈!` 디자인을 수정했습니다.
* 로그인 페이지 보상 안내 문구를 모달 문구와 동일하게 맞췄습니다.

## 주요 변경 사항

### Frontend Components
* **BalanceGameCard 컴포넌트 수정** (`frontend/openpoll/src/pages/balance/components/BalanceGameCard.tsx`)
   * HOT 배지 표시 조건을 `participants >= 3000`에서 `hotRank <= 3` 기준으로 변경
   * HOT 배지 UI를 기존 스타일(불꽃 아이콘 + `핫이슈!`)로 복구
   * Top3 랭킹 기반 배지 노출 로직 반영

* **Login 페이지 문구 수정** (`frontend/openpoll/src/pages/auth/Login.tsx`)
   * 보상 문구를 `로그인 시 500P 지급!` → `회원가입 시 500P 지급!`로 변경
   * 로그인 모달과 안내 문구 일관성 확보


### State Management
* **useBalanceList 훅 업데이트** (`frontend/openpoll/src/pages/balance/hooks/useBalanceList.ts`)
   * `hotRankMap` 계산 로직 추가: 참여자 수 기준 전체 이슈 랭킹 계산
   * `hotRankMap`을 리스트 렌더링 계층으로 전달하도록 반환값 확장


### Layout & API
* **BalanceList 페이지 수정** (`frontend/openpoll/src/pages/balance/BalanceList.tsx`)
   * 카드 렌더링 시 `hotRank` prop 전달
   * 필터/레이아웃 구조 변경 없이 HOT 표시 기준만 연결

## 스크린샷 (선택사항)
<img width="1045" height="407" alt="image" src="https://github.com/user-attachments/assets/9fc9ede5-324c-4ca1-acc1-20148ef5183d" />

### HOT 배지 노출
* Top3 이슈에만 배지가 표시되는 화면 확인
* 배지 스타일은 기존 `핫이슈!` UI 유지

### 로그인 보상 안내 문구
* 로그인 페이지 하단 보상 안내 문구 변경 확인
* 로그인 모달과 동일 문구로 일치

## 테스트 체크리스트

- [ ] 로컬 환경에서 정상 동작 확인
- [ ] 주요 기능 테스트 완료
- [ ] 에러 핸들링 확인
- [ ] 브라우저 콘솔 에러 없음
- [ ] HOT 배지가 Top3 이슈에만 노출되는지 확인
- [ ] 로그인 페이지 보상 문구가 모달과 동일한지 확인

## PR 체크리스트

✅ **아래 규칙 한번더 확인해 주세요~!**
* commit 메시지 규칙 : `prefix: 커밋내용 요약`
  * prefix 예시: `Feat`, `Fix`, `Refactor`, `Style`, `Docs`, `Chore`
* PR 제목 규칙 : `[Prefix] 주요 변경사항 요약`

✅ **아래 항목을 충족하는지 확인해 주세요~!**
- [ ] Reviewers 설정
- [ ] Assignees 본인으로 설정
- [ ] Labels 추가 (선택사항)

---

