### PR TITLE
feat(dos): 결과 카드 시스템 + 공유 모달 리디자인

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -207,14 +207,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -294,10 +294,11 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -894,15 +895,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -1296,9 +1298,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -1536,9 +1539,10 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
-      "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1726,15 +1730,17 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1774,9 +1780,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/frontend/openpoll/.gitignore
+++ b/frontend/openpoll/.gitignore
@@ -41,3 +41,8 @@ dist-ssr
 .gemini/
 .opencode/
 .windsurf/
+
+# OG 이미지 생성 캐시 및 빌드 산출물
+scripts/fonts/
+scripts/twemoji/
+dist/og/

--- a/frontend/openpoll/package-lock.json
+++ b/frontend/openpoll/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.13.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "html-to-image": "^1.11.13",
         "lucide-react": "^0.563.0",
         "motion": "^12.29.0",
         "qrcode.react": "^4.2.0",
@@ -2444,6 +2445,12 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",

--- a/frontend/openpoll/package-lock.json
+++ b/frontend/openpoll/package-lock.json
@@ -1477,9 +1477,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1654,14 +1654,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/bail": {
@@ -1702,9 +1702,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2506,9 +2506,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4208,9 +4208,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4277,10 +4277,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/frontend/openpoll/package-lock.json
+++ b/frontend/openpoll/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@resvg/resvg-js": "^2.6.2",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",
@@ -32,6 +33,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "satori": "^0.26.0",
         "tailwindcss": "^4.1.3",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
@@ -650,6 +652,234 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-beta.50",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.50.tgz",
@@ -894,6 +1124,23 @@
       "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -1434,6 +1681,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.17",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
@@ -1510,6 +1767,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1705,6 +1972,52 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1810,6 +2123,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1864,6 +2187,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2116,6 +2446,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2444,6 +2781,19 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-to-image": {
@@ -2941,6 +3291,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -3763,6 +4124,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3774,6 +4142,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
       }
     },
     "node_modules/parse-entities": {
@@ -3869,6 +4248,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -4094,6 +4480,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/satori": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+      "integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4158,6 +4567,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4250,6 +4666,13 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4366,6 +4789,17 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -4645,6 +5079,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/frontend/openpoll/package.json
+++ b/frontend/openpoll/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.13.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^0.563.0",
     "motion": "^12.29.0",
     "qrcode.react": "^4.2.0",

--- a/frontend/openpoll/package.json
+++ b/frontend/openpoll/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
-    "build": "vite build && node scripts/seo-prerender.mjs",
+    "build": "vite build && node scripts/og-generator.mjs && node scripts/seo-prerender.mjs",
     "typecheck": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/frontend/openpoll/package.json
+++ b/frontend/openpoll/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@resvg/resvg-js": "^2.6.2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
@@ -35,6 +36,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "satori": "^0.26.0",
     "tailwindcss": "^4.1.3",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",

--- a/frontend/openpoll/scripts/og-generator.mjs
+++ b/frontend/openpoll/scripts/og-generator.mjs
@@ -25,26 +25,26 @@ const EMOJI_MAP = {
 // 주의: 이 매핑은 src/shared/constants/dosResultTypes.ts의 animal/color/tagline과 동일하게 유지해야 한다.
 // 스펙 문서 docs/superpowers/specs/2026-04-18-dos-result-card-design.md가 단일 진실 원천.
 const TYPES = [
-  { id: 'CMFD', name: '진보적 자유주의자', emoji: '🦁', animal: '사자',   color: '#FF7A59', tagline: '변화 속에서 기회를 포착하는 불꽃' },
-  { id: 'CMFN', name: '녹색 진보주의자',   emoji: '🦋', animal: '나비',   color: '#4ADE80', tagline: '자유롭게 변화하는 생태의 수호자' },
-  { id: 'CMOD', name: '진보적 권위주의자', emoji: '🐺', animal: '늑대',   color: '#8B5CF6', tagline: '조직된 힘으로 세상을 바꾸는 전략가' },
-  { id: 'CMON', name: '진보적 보존주의자', emoji: '🦉', animal: '올빼미', color: '#0EA5E9', tagline: '변화 속에서 균형을 찾는 현자' },
-  { id: 'CEFD', name: '진보적 평등주의자', emoji: '🐝', animal: '벌',     color: '#F59E0B', tagline: '연대로 움직이는 진보의 일꾼' },
-  { id: 'CEFN', name: '녹색 평등주의자',   emoji: '🦦', animal: '수달',   color: '#65A30D', tagline: '함께 살아가는 자연의 친구' },
-  { id: 'CEOD', name: '진보적 사회주의자', emoji: '🐘', animal: '코끼리', color: '#EC4899', tagline: '공동체를 이끄는 든든한 기둥' },
-  { id: 'CEON', name: '생태 사회주의자',   emoji: '🐳', animal: '고래',   color: '#0D9488', tagline: '깊고 넓은 연대의 바다' },
-  { id: 'SMFD', name: '자유주의적 보수',   emoji: '🦅', animal: '독수리', color: '#D97706', tagline: '높은 곳에서 기회를 노리는 개척자' },
-  { id: 'SMFN', name: '녹색 보수주의자',   emoji: '🦌', animal: '사슴',   color: '#16A34A', tagline: '숲을 지키는 조용한 수호자' },
-  { id: 'SMOD', name: '전통적 보수주의자', emoji: '🐅', animal: '호랑이', color: '#6366F1', tagline: '당당한 원칙의 수호자' },
-  { id: 'SMON', name: '온건 보수주의자',   emoji: '🐢', animal: '거북이', color: '#64748B', tagline: '신중하게 지켜내는 균형의 달인' },
-  { id: 'SEFD', name: '사회민주주의자',    emoji: '🐬', animal: '돌고래', color: '#DC2626', tagline: '따뜻한 연대의 항해자' },
-  { id: 'SEFN', name: '녹색 사민주의자',   emoji: '🐑', animal: '양',     color: '#059669', tagline: '평화로운 공동체의 일원' },
-  { id: 'SEOD', name: '온건 사회주의자',   emoji: '🐻', animal: '곰',     color: '#A855F7', tagline: '든든하게 함께 걷는 동반자' },
-  { id: 'SEON', name: '생태 보수주의자',   emoji: '🐼', animal: '판다',   color: '#78716C', tagline: '자연과 함께하는 평온의 상징' },
+  { id: 'CMFD', name: '진보적 자유주의자', emoji: '🦁', animal: '사자',   color: '#FF7A59', tagline: '변화 속에서 기회를 포착하는 불꽃', keywords: ['자유시장', '규제완화', '스타트업'] },
+  { id: 'CMFN', name: '녹색 진보주의자',   emoji: '🦋', animal: '나비',   color: '#4ADE80', tagline: '자유롭게 변화하는 생태의 수호자', keywords: ['지속가능성', '친환경혁신', '그린뉴딜'] },
+  { id: 'CMOD', name: '진보적 권위주의자', emoji: '🐺', animal: '늑대',   color: '#8B5CF6', tagline: '조직된 힘으로 세상을 바꾸는 전략가', keywords: ['국가주도', '강력한리더', '체제개혁'] },
+  { id: 'CMON', name: '진보적 보존주의자', emoji: '🦉', animal: '올빼미', color: '#0EA5E9', tagline: '변화 속에서 균형을 찾는 현자', keywords: ['온건개혁', '사회질서', '친환경'] },
+  { id: 'CEFD', name: '진보적 평등주의자', emoji: '🐝', animal: '벌',     color: '#F59E0B', tagline: '연대로 움직이는 진보의 일꾼', keywords: ['사회연대', '평등분배', '공동체'] },
+  { id: 'CEFN', name: '녹색 평등주의자',   emoji: '🦦', animal: '수달',   color: '#65A30D', tagline: '함께 살아가는 자연의 친구', keywords: ['생태공존', '평등분배', '지역공동체'] },
+  { id: 'CEOD', name: '진보적 사회주의자', emoji: '🐘', animal: '코끼리', color: '#EC4899', tagline: '공동체를 이끄는 든든한 기둥', keywords: ['사회주의', '국가복지', '산업재편'] },
+  { id: 'CEON', name: '생태 사회주의자',   emoji: '🐳', animal: '고래',   color: '#0D9488', tagline: '깊고 넓은 연대의 바다', keywords: ['생태사회', '연대경제', '탈성장'] },
+  { id: 'SMFD', name: '자유주의적 보수',   emoji: '🦅', animal: '독수리', color: '#D97706', tagline: '높은 곳에서 기회를 노리는 개척자', keywords: ['자유시장', '개인책임', '기업가정신'] },
+  { id: 'SMFN', name: '녹색 보수주의자',   emoji: '🦌', animal: '사슴',   color: '#16A34A', tagline: '숲을 지키는 조용한 수호자', keywords: ['전통보전', '친환경', '지역주의'] },
+  { id: 'SMOD', name: '전통적 보수주의자', emoji: '🐅', animal: '호랑이', color: '#6366F1', tagline: '당당한 원칙의 수호자', keywords: ['전통가치', '질서존중', '강한국가'] },
+  { id: 'SMON', name: '온건 보수주의자',   emoji: '🐢', animal: '거북이', color: '#64748B', tagline: '신중하게 지켜내는 균형의 달인', keywords: ['안정우선', '점진적변화', '환경보호'] },
+  { id: 'SEFD', name: '사회민주주의자',    emoji: '🐬', animal: '돌고래', color: '#DC2626', tagline: '따뜻한 연대의 항해자',           keywords: ['사회복지', '개인자유', '포용사회'] },
+  { id: 'SEFN', name: '녹색 사민주의자',   emoji: '🐑', animal: '양',     color: '#059669', tagline: '평화로운 공동체의 일원',         keywords: ['평화연대', '공공복지', '환경우선'] },
+  { id: 'SEOD', name: '온건 사회주의자',   emoji: '🐻', animal: '곰',     color: '#A855F7', tagline: '든든하게 함께 걷는 동반자',       keywords: ['공공주도', '안정복지', '공정분배'] },
+  { id: 'SEON', name: '생태 보수주의자',   emoji: '🐼', animal: '판다',   color: '#78716C', tagline: '자연과 함께하는 평온의 상징',     keywords: ['자연보전', '공동체', '지속가능'] },
 ]
 
-const CFG_OG = { w: 1200, h: 630,  leftRatio: 40, pad: 48, gap: 16, emoji: 240, code: 80,  animal: 22, label: 16, name: 48, tagline: 20, logo: 14 }
-const CFG_SQ = { w: 1080, h: 1080, leftRatio: 45, pad: 60, gap: 24, emoji: 360, code: 100, animal: 28, label: 20, name: 56, tagline: 24, logo: 16 }
+const CFG_OG = { w: 1200, h: 630,  leftRatio: 40, pad: 40, gap: 14, emoji: 220, code: 72, animal: 22, label: 14, name: 38, tagline: 18, logo: 13, kw: 13 }
+const CFG_SQ = { w: 1080, h: 1080, leftRatio: 45, pad: 60, gap: 24, emoji: 360, code: 100, animal: 28, label: 20, name: 56, tagline: 24, logo: 16, kw: 16 }
 
 async function ensureFont() {
   await mkdir(FONT_DIR, { recursive: true })
@@ -116,9 +116,30 @@ async function buildNode(type, cfg) {
                   style: {
                     display: 'flex',
                     fontSize: cfg.tagline, padding: '12px 16px', background: 'white',
-                    border: '2px solid #1a1a1a', borderRadius: 10, color: '#333',
+                    border: '2px solid #1a1a1a', borderRadius: 12, color: '#333',
                   },
                   children: `"${type.tagline}"`,
+                },
+              },
+              {
+                type: 'div',
+                props: {
+                  style: {
+                    display: 'flex', flexWrap: 'wrap',
+                    gap: 8,
+                  },
+                  children: type.keywords.map((kw) => ({
+                    type: 'div',
+                    props: {
+                      style: {
+                        display: 'flex',
+                        fontSize: cfg.kw, fontWeight: 700, color: type.color,
+                        background: 'white', border: `1.5px solid ${type.color}`,
+                        padding: '4px 12px', borderRadius: 100,
+                      },
+                      children: `#${kw}`,
+                    },
+                  })),
                 },
               },
               {

--- a/frontend/openpoll/scripts/og-generator.mjs
+++ b/frontend/openpoll/scripts/og-generator.mjs
@@ -1,0 +1,171 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import satori from 'satori'
+import { Resvg } from '@resvg/resvg-js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..')
+const FONT_DIR = join(__dirname, 'fonts')
+const EMOJI_DIR = join(__dirname, 'twemoji')
+const OUT_DIR = join(ROOT, 'dist/og/dos')
+
+const TWEMOJI_VERSION = '14.0.2'
+const FONT_URL = 'https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/packages/pretendard/dist/public/static/Pretendard-Bold.otf'
+const FONT_PATH = join(FONT_DIR, 'Pretendard-Bold.otf')
+
+const EMOJI_MAP = {
+  '🦁': '1f981', '🦋': '1f98b', '🐺': '1f43a', '🦉': '1f989',
+  '🐝': '1f41d', '🦦': '1f9a6', '🐘': '1f418', '🐳': '1f433',
+  '🦅': '1f985', '🦌': '1f98c', '🐅': '1f405', '🐢': '1f422',
+  '🐬': '1f42c', '🐑': '1f411', '🐻': '1f43b', '🐼': '1f43c',
+}
+
+// 주의: 이 매핑은 src/shared/constants/dosResultTypes.ts의 animal/color/tagline과 동일하게 유지해야 한다.
+// 스펙 문서 docs/superpowers/specs/2026-04-18-dos-result-card-design.md가 단일 진실 원천.
+const TYPES = [
+  { id: 'CMFD', name: '진보적 자유주의자', emoji: '🦁', animal: '사자',   color: '#FF7A59', tagline: '변화 속에서 기회를 포착하는 불꽃' },
+  { id: 'CMFN', name: '녹색 진보주의자',   emoji: '🦋', animal: '나비',   color: '#4ADE80', tagline: '자유롭게 변화하는 생태의 수호자' },
+  { id: 'CMOD', name: '진보적 권위주의자', emoji: '🐺', animal: '늑대',   color: '#8B5CF6', tagline: '조직된 힘으로 세상을 바꾸는 전략가' },
+  { id: 'CMON', name: '진보적 보존주의자', emoji: '🦉', animal: '올빼미', color: '#0EA5E9', tagline: '변화 속에서 균형을 찾는 현자' },
+  { id: 'CEFD', name: '진보적 평등주의자', emoji: '🐝', animal: '벌',     color: '#F59E0B', tagline: '연대로 움직이는 진보의 일꾼' },
+  { id: 'CEFN', name: '녹색 평등주의자',   emoji: '🦦', animal: '수달',   color: '#65A30D', tagline: '함께 살아가는 자연의 친구' },
+  { id: 'CEOD', name: '진보적 사회주의자', emoji: '🐘', animal: '코끼리', color: '#EC4899', tagline: '공동체를 이끄는 든든한 기둥' },
+  { id: 'CEON', name: '생태 사회주의자',   emoji: '🐳', animal: '고래',   color: '#0D9488', tagline: '깊고 넓은 연대의 바다' },
+  { id: 'SMFD', name: '자유주의적 보수',   emoji: '🦅', animal: '독수리', color: '#D97706', tagline: '높은 곳에서 기회를 노리는 개척자' },
+  { id: 'SMFN', name: '녹색 보수주의자',   emoji: '🦌', animal: '사슴',   color: '#16A34A', tagline: '숲을 지키는 조용한 수호자' },
+  { id: 'SMOD', name: '전통적 보수주의자', emoji: '🐅', animal: '호랑이', color: '#6366F1', tagline: '당당한 원칙의 수호자' },
+  { id: 'SMON', name: '온건 보수주의자',   emoji: '🐢', animal: '거북이', color: '#64748B', tagline: '신중하게 지켜내는 균형의 달인' },
+  { id: 'SEFD', name: '사회민주주의자',    emoji: '🐬', animal: '돌고래', color: '#DC2626', tagline: '따뜻한 연대의 항해자' },
+  { id: 'SEFN', name: '녹색 사민주의자',   emoji: '🐑', animal: '양',     color: '#059669', tagline: '평화로운 공동체의 일원' },
+  { id: 'SEOD', name: '온건 사회주의자',   emoji: '🐻', animal: '곰',     color: '#A855F7', tagline: '든든하게 함께 걷는 동반자' },
+  { id: 'SEON', name: '생태 보수주의자',   emoji: '🐼', animal: '판다',   color: '#78716C', tagline: '자연과 함께하는 평온의 상징' },
+]
+
+const CFG_OG = { w: 1200, h: 630,  leftRatio: 40, pad: 48, gap: 16, emoji: 240, code: 80,  animal: 22, label: 16, name: 48, tagline: 20, logo: 14 }
+const CFG_SQ = { w: 1080, h: 1080, leftRatio: 45, pad: 60, gap: 24, emoji: 360, code: 100, animal: 28, label: 20, name: 56, tagline: 24, logo: 16 }
+
+async function ensureFont() {
+  await mkdir(FONT_DIR, { recursive: true })
+  if (existsSync(FONT_PATH)) return readFile(FONT_PATH)
+  console.log('[og-generator] Pretendard Bold 다운로드 중...')
+  const res = await fetch(FONT_URL)
+  if (!res.ok) throw new Error(`폰트 다운로드 실패: ${res.status}`)
+  const buf = Buffer.from(await res.arrayBuffer())
+  await writeFile(FONT_PATH, buf)
+  return buf
+}
+
+async function ensureEmojiSvg(unicode) {
+  await mkdir(EMOJI_DIR, { recursive: true })
+  const path = join(EMOJI_DIR, `${unicode}.svg`)
+  if (existsSync(path)) return readFile(path, 'utf8')
+  const url = `https://cdn.jsdelivr.net/gh/twitter/twemoji@${TWEMOJI_VERSION}/assets/svg/${unicode}.svg`
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`이모지 다운로드 실패 (${unicode}): ${res.status}`)
+  const svg = await res.text()
+  await writeFile(path, svg)
+  return svg
+}
+
+async function getEmojiDataUrl(emoji) {
+  const unicode = EMOJI_MAP[emoji]
+  if (!unicode) throw new Error(`매핑 없음: ${emoji}`)
+  const svg = await ensureEmojiSvg(unicode)
+  const b64 = Buffer.from(svg).toString('base64')
+  return `data:image/svg+xml;base64,${b64}`
+}
+
+async function buildNode(type, cfg) {
+  const emojiDataUrl = await getEmojiDataUrl(type.emoji)
+  return {
+    type: 'div',
+    props: {
+      style: { width: cfg.w, height: cfg.h, display: 'flex', fontFamily: 'Pretendard', background: '#FFF9E6', color: '#1a1a1a' },
+      children: [
+        {
+          type: 'div',
+          props: {
+            style: {
+              display: 'flex', flexDirection: 'column',
+              width: `${cfg.leftRatio}%`, background: type.color,
+              alignItems: 'center', justifyContent: 'center',
+              padding: cfg.pad, color: 'white', gap: cfg.gap,
+            },
+            children: [
+              { type: 'img', props: { src: emojiDataUrl, width: cfg.emoji, height: cfg.emoji, style: { display: 'block' } } },
+              { type: 'div', props: { style: { display: 'flex', fontSize: cfg.code, fontWeight: 900, letterSpacing: -4 }, children: type.id } },
+              { type: 'div', props: { style: { display: 'flex', fontSize: cfg.animal, opacity: 0.9, fontWeight: 700 }, children: type.animal } },
+            ],
+          },
+        },
+        {
+          type: 'div',
+          props: {
+            style: {
+              display: 'flex', flexDirection: 'column',
+              flexGrow: 1, padding: cfg.pad, gap: cfg.gap, background: '#FFF9E6',
+            },
+            children: [
+              { type: 'div', props: { style: { display: 'flex', fontSize: cfg.label, fontWeight: 700, letterSpacing: 4, color: '#666' }, children: '나의 DOS 유형' } },
+              { type: 'div', props: { style: { display: 'flex', fontSize: cfg.name, fontWeight: 900 }, children: type.name } },
+              {
+                type: 'div',
+                props: {
+                  style: {
+                    display: 'flex',
+                    fontSize: cfg.tagline, padding: '12px 16px', background: 'white',
+                    border: '2px solid #1a1a1a', borderRadius: 10, color: '#333',
+                  },
+                  children: `"${type.tagline}"`,
+                },
+              },
+              {
+                type: 'div',
+                props: {
+                  style: { display: 'flex', marginTop: 'auto', fontSize: cfg.logo, fontWeight: 800, letterSpacing: 3, color: '#666' },
+                  children: 'OPENPOLL.CO.KR',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  }
+}
+
+async function main() {
+  const fontBuf = await ensureFont()
+  await mkdir(OUT_DIR, { recursive: true })
+
+  const variants = [
+    { name: 'og', cfg: CFG_OG },
+    { name: 'sq', cfg: CFG_SQ },
+  ]
+
+  let count = 0
+  for (const type of TYPES) {
+    for (const v of variants) {
+      const node = await buildNode(type, v.cfg)
+      const svg = await satori(node, {
+        width: v.cfg.w,
+        height: v.cfg.h,
+        fonts: [{ name: 'Pretendard', data: fontBuf, weight: 700, style: 'normal' }],
+      })
+      const resvg = new Resvg(svg)
+      const pngBuf = resvg.render().asPng()
+      const outPath = join(OUT_DIR, `${type.id}-${v.name}.png`)
+      await writeFile(outPath, pngBuf)
+      count++
+      process.stdout.write(`\r[og-generator] ${count}/32 생성 중... (${type.id}-${v.name})`)
+    }
+  }
+  console.log(`\n[og-generator] ${count}개 PNG 생성 완료 → ${OUT_DIR}`)
+}
+
+main().catch((err) => {
+  console.error('[og-generator] 실패:', err)
+  process.exit(1)
+})

--- a/frontend/openpoll/scripts/og-generator.mjs
+++ b/frontend/openpoll/scripts/og-generator.mjs
@@ -22,29 +22,31 @@ const EMOJI_MAP = {
   '🐬': '1f42c', '🐑': '1f411', '🐻': '1f43b', '🐼': '1f43c',
 }
 
-// 주의: 이 매핑은 src/shared/constants/dosResultTypes.ts의 animal/color/tagline과 동일하게 유지해야 한다.
+// 주의: 이 매핑은 src/shared/constants/dosResultTypes.ts의 animal/color/tagline/description과 동일하게 유지해야 한다.
 // 스펙 문서 docs/superpowers/specs/2026-04-18-dos-result-card-design.md가 단일 진실 원천.
 const TYPES = [
-  { id: 'CMFD', name: '진보적 자유주의자', emoji: '🦁', animal: '사자',   color: '#FF7A59', tagline: '변화 속에서 기회를 포착하는 불꽃', keywords: ['자유시장', '규제완화', '스타트업'] },
-  { id: 'CMFN', name: '녹색 진보주의자',   emoji: '🦋', animal: '나비',   color: '#4ADE80', tagline: '자유롭게 변화하는 생태의 수호자', keywords: ['지속가능성', '친환경혁신', '그린뉴딜'] },
-  { id: 'CMOD', name: '진보적 권위주의자', emoji: '🐺', animal: '늑대',   color: '#8B5CF6', tagline: '조직된 힘으로 세상을 바꾸는 전략가', keywords: ['국가주도', '강력한리더', '체제개혁'] },
-  { id: 'CMON', name: '진보적 보존주의자', emoji: '🦉', animal: '올빼미', color: '#0EA5E9', tagline: '변화 속에서 균형을 찾는 현자', keywords: ['온건개혁', '사회질서', '친환경'] },
-  { id: 'CEFD', name: '진보적 평등주의자', emoji: '🐝', animal: '벌',     color: '#F59E0B', tagline: '연대로 움직이는 진보의 일꾼', keywords: ['사회연대', '평등분배', '공동체'] },
-  { id: 'CEFN', name: '녹색 평등주의자',   emoji: '🦦', animal: '수달',   color: '#65A30D', tagline: '함께 살아가는 자연의 친구', keywords: ['생태공존', '평등분배', '지역공동체'] },
-  { id: 'CEOD', name: '진보적 사회주의자', emoji: '🐘', animal: '코끼리', color: '#EC4899', tagline: '공동체를 이끄는 든든한 기둥', keywords: ['사회주의', '국가복지', '산업재편'] },
-  { id: 'CEON', name: '생태 사회주의자',   emoji: '🐳', animal: '고래',   color: '#0D9488', tagline: '깊고 넓은 연대의 바다', keywords: ['생태사회', '연대경제', '탈성장'] },
-  { id: 'SMFD', name: '자유주의적 보수',   emoji: '🦅', animal: '독수리', color: '#D97706', tagline: '높은 곳에서 기회를 노리는 개척자', keywords: ['자유시장', '개인책임', '기업가정신'] },
-  { id: 'SMFN', name: '녹색 보수주의자',   emoji: '🦌', animal: '사슴',   color: '#16A34A', tagline: '숲을 지키는 조용한 수호자', keywords: ['전통보전', '친환경', '지역주의'] },
-  { id: 'SMOD', name: '전통적 보수주의자', emoji: '🐅', animal: '호랑이', color: '#6366F1', tagline: '당당한 원칙의 수호자', keywords: ['전통가치', '질서존중', '강한국가'] },
-  { id: 'SMON', name: '온건 보수주의자',   emoji: '🐢', animal: '거북이', color: '#64748B', tagline: '신중하게 지켜내는 균형의 달인', keywords: ['안정우선', '점진적변화', '환경보호'] },
-  { id: 'SEFD', name: '사회민주주의자',    emoji: '🐬', animal: '돌고래', color: '#DC2626', tagline: '따뜻한 연대의 항해자',           keywords: ['사회복지', '개인자유', '포용사회'] },
-  { id: 'SEFN', name: '녹색 사민주의자',   emoji: '🐑', animal: '양',     color: '#059669', tagline: '평화로운 공동체의 일원',         keywords: ['평화연대', '공공복지', '환경우선'] },
-  { id: 'SEOD', name: '온건 사회주의자',   emoji: '🐻', animal: '곰',     color: '#A855F7', tagline: '든든하게 함께 걷는 동반자',       keywords: ['공공주도', '안정복지', '공정분배'] },
-  { id: 'SEON', name: '생태 보수주의자',   emoji: '🐼', animal: '판다',   color: '#78716C', tagline: '자연과 함께하는 평온의 상징',     keywords: ['자연보전', '공동체', '지속가능'] },
+  { id: 'CMFD', name: '진보적 자유주의자', emoji: '🦁', animal: '사자',   color: '#FF7A59', tagline: '변화 속에서 기회를 포착하는 불꽃', keywords: ['자유시장', '규제완화', '스타트업'],  description: '변화를 추구하며 개인의 자유와 경쟁을 중시하고, 발전을 위한 개발에 긍정적인 유형입니다.' },
+  { id: 'CMFN', name: '녹색 진보주의자',   emoji: '🦋', animal: '나비',   color: '#4ADE80', tagline: '자유롭게 변화하는 생태의 수호자', keywords: ['지속가능성', '친환경혁신', '그린뉴딜'], description: '변화와 자유를 중시하되, 환경 보존에 높은 가치를 두는 유형입니다.' },
+  { id: 'CMOD', name: '진보적 권위주의자', emoji: '🐺', animal: '늑대',   color: '#8B5CF6', tagline: '조직된 힘으로 세상을 바꾸는 전략가', keywords: ['국가주도', '강력한리더', '체제개혁'], description: '변화와 경쟁을 지지하면서 사회 질서를 중시하고, 개발에 적극적인 유형입니다.' },
+  { id: 'CMON', name: '진보적 보존주의자', emoji: '🦉', animal: '올빼미', color: '#0EA5E9', tagline: '변화 속에서 균형을 찾는 현자', keywords: ['온건개혁', '사회질서', '친환경'], description: '변화를 추구하지만 규율을 중시하며, 환경 보존에 관심이 높은 유형입니다.' },
+  { id: 'CEFD', name: '진보적 평등주의자', emoji: '🐝', animal: '벌',     color: '#F59E0B', tagline: '연대로 움직이는 진보의 일꾼', keywords: ['사회연대', '평등분배', '공동체'], description: '변화를 추구하고 분배를 중시하며, 개인 자유와 발전을 지지하는 유형입니다.' },
+  { id: 'CEFN', name: '녹색 평등주의자',   emoji: '🦦', animal: '수달',   color: '#65A30D', tagline: '함께 살아가는 자연의 친구', keywords: ['생태공존', '평등분배', '지역공동체'], description: '변화와 분배, 자유를 중시하면서 환경 가치를 지키려는 유형입니다.' },
+  { id: 'CEOD', name: '진보적 사회주의자', emoji: '🐘', animal: '코끼리', color: '#EC4899', tagline: '공동체를 이끄는 든든한 기둥', keywords: ['사회주의', '국가복지', '산업재편'], description: '변화와 분배, 질서를 모두 중시하고 적극적으로 개발에 관여하는 유형입니다.' },
+  { id: 'CEON', name: '생태 사회주의자',   emoji: '🐳', animal: '고래',   color: '#0D9488', tagline: '깊고 넓은 연대의 바다', keywords: ['생태사회', '연대경제', '탈성장'], description: '변화와 분배, 질서를 중시하되 환경 보존에 깊은 관심을 가진 유형입니다.' },
+  { id: 'SMFD', name: '자유주의적 보수',   emoji: '🦅', animal: '독수리', color: '#D97706', tagline: '높은 곳에서 기회를 노리는 개척자', keywords: ['자유시장', '개인책임', '기업가정신'], description: '안정 속에서 개인의 자유와 경쟁을 강조하며, 개발에 긍정적인 유형입니다.' },
+  { id: 'SMFN', name: '녹색 보수주의자',   emoji: '🦌', animal: '사슴',   color: '#16A34A', tagline: '숲을 지키는 조용한 수호자', keywords: ['전통보전', '친환경', '지역주의'], description: '안정과 자유를 중시하면서 환경 가치를 지키려는 유형입니다.' },
+  { id: 'SMOD', name: '전통적 보수주의자', emoji: '🐅', animal: '호랑이', color: '#6366F1', tagline: '당당한 원칙의 수호자', keywords: ['전통가치', '질서존중', '강한국가'], description: '안정과 질서를 중시하며, 경쟁과 개발에 적극적인 전통적 유형입니다.' },
+  { id: 'SMON', name: '온건 보수주의자',   emoji: '🐢', animal: '거북이', color: '#64748B', tagline: '신중하게 지켜내는 균형의 달인', keywords: ['안정우선', '점진적변화', '환경보호'], description: '안정과 질서를 중시하면서 환경 보호에도 관심을 두는 신중한 유형입니다.' },
+  { id: 'SEFD', name: '사회민주주의자',    emoji: '🐬', animal: '돌고래', color: '#DC2626', tagline: '따뜻한 연대의 항해자',           keywords: ['사회복지', '개인자유', '포용사회'], description: '안정 속에서 분배와 자유를 중시하며, 발전에도 긍정적인 유형입니다.' },
+  { id: 'SEFN', name: '녹색 사민주의자',   emoji: '🐑', animal: '양',     color: '#059669', tagline: '평화로운 공동체의 일원',         keywords: ['평화연대', '공공복지', '환경우선'], description: '안정과 분배, 자유를 존중하면서 환경 보존을 중요시하는 유형입니다.' },
+  { id: 'SEOD', name: '온건 사회주의자',   emoji: '🐻', animal: '곰',     color: '#A855F7', tagline: '든든하게 함께 걷는 동반자',       keywords: ['공공주도', '안정복지', '공정분배'], description: '안정과 분배, 질서를 중시하며, 발전 방향에도 관심이 많은 유형입니다.' },
+  { id: 'SEON', name: '생태 보수주의자',   emoji: '🐼', animal: '판다',   color: '#78716C', tagline: '자연과 함께하는 평온의 상징',     keywords: ['자연보전', '공동체', '지속가능'], description: '안정과 분배, 질서를 중시하면서 환경 가치를 지키려는 유형입니다.' },
 ]
 
-const CFG_OG = { w: 1200, h: 630,  leftRatio: 40, pad: 40, gap: 14, emoji: 220, code: 72, animal: 22, label: 14, name: 38, tagline: 18, logo: 13, kw: 13 }
-const CFG_SQ = { w: 1080, h: 1080, leftRatio: 45, pad: 60, gap: 24, emoji: 360, code: 100, animal: 28, label: 20, name: 56, tagline: 24, logo: 16, kw: 16 }
+// 현재 DosResultCard.tsx와 시각 언어 동기화: 폰트 크기 업, 키워드/태그라인 스타일 조정,
+// square variant는 저장용으로 borderRadius 0 + description 포함.
+const CFG_OG = { w: 1200, h: 630,  leftRatio: 40, padY: 48, padX: 52, gap: 26, emoji: 240, code: 56, animal: 18, label: 16, name: 44, tagline: 20, logo: 15, kw: 16, codeBottom: 36, borderRadius: 24, kwPad: '7px 14px', kwGap: 10, tlPad: '11px 18px', tlRadius: 14, showDesc: false, desc: 0 }
+const CFG_SQ = { w: 1080, h: 1080, leftRatio: 45, padY: 64, padX: 60, gap: 34, emoji: 380, code: 88, animal: 26, label: 22, name: 60, tagline: 26, logo: 18, kw: 18, codeBottom: 56, borderRadius: 0,  kwPad: '7px 14px', kwGap: 10, tlPad: '14px 20px', tlRadius: 14, showDesc: true,  desc: 22 }
 
 async function ensureFont() {
   await mkdir(FONT_DIR, { recursive: true })
@@ -79,24 +81,121 @@ async function getEmojiDataUrl(emoji) {
 
 async function buildNode(type, cfg) {
   const emojiDataUrl = await getEmojiDataUrl(type.emoji)
+  const rightChildren = [
+    { type: 'div', props: { style: { display: 'flex', fontSize: cfg.label, fontWeight: 700, letterSpacing: 4, color: '#666' }, children: '나의 DOS 유형' } },
+    { type: 'div', props: { style: { display: 'flex', fontSize: cfg.name, fontWeight: 900, letterSpacing: -2, lineHeight: 1.1 }, children: type.name } },
+    {
+      type: 'div',
+      props: {
+        style: {
+          display: 'flex',
+          alignSelf: 'flex-start',
+          maxWidth: '100%',
+          fontSize: cfg.tagline, fontWeight: 600,
+          padding: cfg.tlPad, background: 'white',
+          border: '2px solid #1a1a1a', borderRadius: cfg.tlRadius, color: '#333',
+        },
+        children: `"${type.tagline}"`,
+      },
+    },
+    {
+      type: 'div',
+      props: {
+        style: { display: 'flex', flexWrap: 'wrap', gap: cfg.kwGap },
+        children: type.keywords.map((kw) => ({
+          type: 'div',
+          props: {
+            style: {
+              display: 'flex',
+              fontSize: cfg.kw, fontWeight: 700, color: type.color,
+              background: 'white', border: `2px solid ${type.color}`,
+              padding: cfg.kwPad, borderRadius: 100,
+            },
+            children: `#${kw}`,
+          },
+        })),
+      },
+    },
+  ]
+
+  if (cfg.showDesc && type.description) {
+    rightChildren.push({
+      type: 'div',
+      props: {
+        style: {
+          display: 'flex',
+          width: '100%',
+          fontSize: cfg.desc, fontWeight: 500,
+          lineHeight: 1.55, color: '#444',
+          wordBreak: 'keep-all',
+        },
+        children: type.description,
+      },
+    })
+  }
+
+  rightChildren.push({
+    type: 'div',
+    props: {
+      style: { display: 'flex', marginTop: 'auto', fontSize: cfg.logo, fontWeight: 800, letterSpacing: 3, color: '#666' },
+      children: 'OPENPOLL.CO.KR',
+    },
+  })
+
   return {
     type: 'div',
     props: {
-      style: { width: cfg.w, height: cfg.h, display: 'flex', fontFamily: 'Pretendard', background: '#FFF9E6', color: '#1a1a1a' },
+      style: {
+        width: cfg.w, height: cfg.h, display: 'flex',
+        fontFamily: 'Pretendard', background: '#FFF9E6', color: '#1a1a1a',
+        borderRadius: cfg.borderRadius, overflow: 'hidden',
+      },
       children: [
         {
           type: 'div',
           props: {
             style: {
-              display: 'flex', flexDirection: 'column',
+              display: 'flex',
               width: `${cfg.leftRatio}%`, background: type.color,
-              alignItems: 'center', justifyContent: 'center',
-              padding: cfg.pad, color: 'white', gap: cfg.gap,
+              position: 'relative', color: 'white',
             },
             children: [
-              { type: 'img', props: { src: emojiDataUrl, width: cfg.emoji, height: cfg.emoji, style: { display: 'block' } } },
-              { type: 'div', props: { style: { display: 'flex', fontSize: cfg.code, fontWeight: 900, letterSpacing: -4 }, children: type.id } },
-              { type: 'div', props: { style: { display: 'flex', fontSize: cfg.animal, opacity: 0.9, fontWeight: 700 }, children: type.animal } },
+              // 이모지: 패널 정중앙
+              {
+                type: 'img',
+                props: {
+                  src: emojiDataUrl,
+                  width: cfg.emoji,
+                  height: cfg.emoji,
+                  style: {
+                    display: 'block',
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                  },
+                },
+              },
+              // ID + 동물명: 하단
+              {
+                type: 'div',
+                props: {
+                  style: {
+                    position: 'absolute',
+                    bottom: cfg.codeBottom,
+                    left: 0,
+                    right: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: Math.max(4, Math.round(cfg.gap / 4)),
+                  },
+                  children: [
+                    { type: 'div', props: { style: { display: 'flex', fontSize: cfg.code, fontWeight: 900, letterSpacing: -3 }, children: type.id } },
+                    { type: 'div', props: { style: { display: 'flex', fontSize: cfg.animal, opacity: 0.9, fontWeight: 700 }, children: type.animal } },
+                  ],
+                },
+              },
             ],
           },
         },
@@ -105,51 +204,12 @@ async function buildNode(type, cfg) {
           props: {
             style: {
               display: 'flex', flexDirection: 'column',
-              flexGrow: 1, padding: cfg.pad, gap: cfg.gap, background: '#FFF9E6',
+              width: `${100 - cfg.leftRatio}%`,
+              padding: `${cfg.padY}px ${cfg.padX}px`,
+              gap: cfg.gap, background: '#FFF9E6',
+              boxSizing: 'border-box',
             },
-            children: [
-              { type: 'div', props: { style: { display: 'flex', fontSize: cfg.label, fontWeight: 700, letterSpacing: 4, color: '#666' }, children: '나의 DOS 유형' } },
-              { type: 'div', props: { style: { display: 'flex', fontSize: cfg.name, fontWeight: 900 }, children: type.name } },
-              {
-                type: 'div',
-                props: {
-                  style: {
-                    display: 'flex',
-                    fontSize: cfg.tagline, padding: '12px 16px', background: 'white',
-                    border: '2px solid #1a1a1a', borderRadius: 12, color: '#333',
-                  },
-                  children: `"${type.tagline}"`,
-                },
-              },
-              {
-                type: 'div',
-                props: {
-                  style: {
-                    display: 'flex', flexWrap: 'wrap',
-                    gap: 8,
-                  },
-                  children: type.keywords.map((kw) => ({
-                    type: 'div',
-                    props: {
-                      style: {
-                        display: 'flex',
-                        fontSize: cfg.kw, fontWeight: 700, color: type.color,
-                        background: 'white', border: `1.5px solid ${type.color}`,
-                        padding: '4px 12px', borderRadius: 100,
-                      },
-                      children: `#${kw}`,
-                    },
-                  })),
-                },
-              },
-              {
-                type: 'div',
-                props: {
-                  style: { display: 'flex', marginTop: 'auto', fontSize: cfg.logo, fontWeight: 800, letterSpacing: 3, color: '#666' },
-                  children: 'OPENPOLL.CO.KR',
-                },
-              },
-            ],
+            children: rightChildren,
           },
         },
       ],

--- a/frontend/openpoll/scripts/seo-prerender.mjs
+++ b/frontend/openpoll/scripts/seo-prerender.mjs
@@ -337,6 +337,32 @@ function generateHTML(template, route) {
     `<meta name="twitter:description" content="${route.description}" />`,
   );
 
+  // og:image & twitter:image 유형별 분기 (DOS 공유 페이지만)
+  if (route.dosType) {
+    const ogImageUrl = `${BASE_URL}/og/dos/${route.dosType.code}-og.png`;
+    const ogImageAlt = `${route.dosType.name} (${route.dosType.code}) - OpenPoll DOS 정치 성향 테스트 결과`;
+    html = replaceTag(
+      html,
+      /<meta property="og:image" content="[^"]*" \/>/,
+      `<meta property="og:image" content="${ogImageUrl}" />`,
+    );
+    html = replaceTag(
+      html,
+      /<meta property="og:image:alt" content="[^"]*" \/>/,
+      `<meta property="og:image:alt" content="${ogImageAlt}" />`,
+    );
+    html = replaceTag(
+      html,
+      /<meta name="twitter:image" content="[^"]*" \/>/,
+      `<meta name="twitter:image" content="${ogImageUrl}" />`,
+    );
+    html = replaceTag(
+      html,
+      /<meta name="twitter:image:alt" content="[^"]*" \/>/,
+      `<meta name="twitter:image:alt" content="${ogImageAlt}" />`,
+    );
+  }
+
   // ── JSON-LD: remove ALL existing blocks + their HTML comment labels ──
   html = html.replace(
     /\s*<!--\s*Structured Data:[^>]*-->\s*<script type="application\/ld\+json">[\s\S]*?<\/script>/g,

--- a/frontend/openpoll/src/pages/dos/DosResult.tsx
+++ b/frontend/openpoll/src/pages/dos/DosResult.tsx
@@ -1,24 +1,60 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { usePageMeta } from "@/hooks/usePageMeta";
 import type { DosResult as DosResultData } from "@/types/api.types";
 import { dosResultTypes } from "@/shared/constants/dosResultTypes";
-import { useResultData, createAxisResults } from "./hooks";
+import { useResultData } from "./hooks";
 import {
   DosResultLoadingState,
   ErrorState,
-  ResultHeader,
-  AxesResultsSection,
   DescriptionSection,
   CharacteristicsSection,
   NoticeSection,
   ActionButtons,
   NavigationLinks,
 } from "./components";
+import { DosResultCard, type DosCardScores } from "./components/DosResultCard";
 import { ShareModal } from "./components/ShareModal";
 import { Toast } from "@/components/molecules/toast/Toast";
 import { AdBanner } from "@/components/atoms/adBanner/AdBanner";
 
+interface DetailsToggleProps {
+  detail: string[];
+  features: string[];
+  tags: string[];
+}
+
+function DetailsToggle({ detail, features, tags }: DetailsToggleProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ marginTop: 32 }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          width: "100%",
+          padding: "16px 20px",
+          background: "var(--color-surface)",
+          border: "1px solid var(--color-border)",
+          borderRadius: 12,
+          fontSize: 16,
+          fontWeight: 700,
+          color: "var(--color-foreground)",
+          cursor: "pointer",
+        }}
+      >
+        {open ? "접기" : "상세 설명 더 보기 ↓"}
+      </button>
+      {open && (
+        <div style={{ marginTop: 16 }}>
+          <DescriptionSection detail={detail} />
+          <CharacteristicsSection features={features} tags={tags} />
+          <NoticeSection />
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function DosResult() {
   usePageMeta("DOS 테스트 결과", "나의 정치 성향 분석 결과를 확인하세요.");
@@ -50,10 +86,30 @@ export function DosResult() {
     [localResultData]
   );
 
-  const axisResults = useMemo(
-    () => createAxisResults(resultData),
-    [resultData]
-  );
+  const cardWrapperRef = useRef<HTMLDivElement>(null);
+  const [cardScale, setCardScale] = useState(1);
+
+  useEffect(() => {
+    const el = cardWrapperRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) setCardScale(width / 1080);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const cardScores: DosCardScores | undefined = useMemo(() => {
+    if (!resultData?.axisPercentages) return undefined;
+    const p = resultData.axisPercentages;
+    return {
+      change: p.change,
+      distribution: p.distribution,
+      rights: p.rights,
+      development: p.development,
+    };
+  }, [resultData]);
 
   if (isLoading) return <DosResultLoadingState />;
   if (!resultTypeInfo) return <ErrorState />;
@@ -61,15 +117,38 @@ export function DosResult() {
   return (
     <div className={`min-h-screen pt-16 bg-background text-foreground`}>
       <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12">
-        <ResultHeader
-          type={type || ""}
-          name={resultTypeInfo.name}
-          description={resultTypeInfo.description}
-        />
-        <AxesResultsSection axisResults={axisResults} hasData={!!resultData} />
-        <DescriptionSection detail={detail} />
-        <CharacteristicsSection features={features} tags={tags} />
-        <NoticeSection />
+        {localResultData && (
+          <div
+            ref={cardWrapperRef}
+            style={{
+              position: "relative",
+              width: "100%",
+              maxWidth: 640,
+              margin: "0 auto",
+              height: 1080 * cardScale,
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: 1080,
+                height: 1080,
+                transform: `scale(${cardScale})`,
+                transformOrigin: "top left",
+              }}
+            >
+              <DosResultCard
+                type={localResultData}
+                scores={cardScores}
+                variant="square"
+              />
+            </div>
+          </div>
+        )}
+        <DetailsToggle detail={detail} features={features} tags={tags} />
         <AdBanner className="mb-8" />
         <ActionButtons onShare={() => setShowShareModal(true)} onImageSave={handleImageSave} />
         <NavigationLinks />
@@ -86,7 +165,7 @@ export function DosResult() {
         type="info"
         isVisible={showToast}
         onClose={() => setShowToast(false)}
-        contentStyle={{ backgroundColor: '#ffffff', color: '#1a1a1a' }}
+        contentStyle={{ backgroundColor: "#ffffff", color: "#1a1a1a" }}
       />
     </div>
   );

--- a/frontend/openpoll/src/pages/dos/DosResult.tsx
+++ b/frontend/openpoll/src/pages/dos/DosResult.tsx
@@ -17,6 +17,7 @@ import { DosResultCard, type DosCardScores } from "./components/DosResultCard";
 import { ShareModal } from "./components/ShareModal";
 import { Toast } from "@/components/molecules/toast/Toast";
 import { AdBanner } from "@/components/atoms/adBanner/AdBanner";
+import { useDosCardDownload } from "./hooks/useDosCardDownload";
 
 interface DetailsToggleProps {
   detail: string[];
@@ -63,10 +64,9 @@ export function DosResult() {
   const navigate = useNavigate();
   const [showShareModal, setShowShareModal] = useState(false);
   const [showToast, setShowToast] = useState(false);
-
-  const handleImageSave = useCallback(() => {
-    setShowToast(true);
-  }, []);
+  const [saveState, setSaveState] = useState<'idle' | 'success' | 'error'>('idle');
+  const captureRef = useRef<HTMLDivElement>(null);
+  const download = useDosCardDownload();
 
   const { resultTypeInfo, isLoading } = useResultData(type, navigate);
 
@@ -76,6 +76,18 @@ export function DosResult() {
     () => dosResultTypes.find((rt) => rt.id === type),
     [type]
   );
+
+  const handleImageSave = useCallback(async () => {
+    if (!localResultData) return;
+    try {
+      await download(captureRef.current, localResultData.id);
+      setSaveState('success');
+    } catch {
+      setSaveState('error');
+    }
+    setShowToast(true);
+    setTimeout(() => setSaveState('idle'), 2500);
+  }, [download, localResultData]);
 
   const { detail, features, tags } = useMemo(
     () => ({
@@ -161,12 +173,30 @@ export function DosResult() {
       />
 
       <Toast
-        message="추후 구현될 기능입니다!"
-        type="info"
+        message={
+          saveState === 'success'
+            ? '결과 카드가 저장됐어요'
+            : saveState === 'error'
+              ? '저장에 실패했어요. 잠시 후 다시 시도해주세요.'
+              : '추후 구현될 기능입니다!'
+        }
+        type={saveState === 'error' ? 'error' : saveState === 'success' ? 'success' : 'info'}
         isVisible={showToast}
         onClose={() => setShowToast(false)}
         contentStyle={{ backgroundColor: "#ffffff", color: "#1a1a1a" }}
       />
+
+      {/* 오프스크린 캡처 타깃: 1080x1080 원본 크기 */}
+      {localResultData && (
+        <div
+          style={{ position: 'fixed', left: -99999, top: 0, pointerEvents: 'none' }}
+          aria-hidden
+        >
+          <div ref={captureRef}>
+            <DosResultCard type={localResultData} scores={cardScores} variant="square" />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/openpoll/src/pages/dos/DosResult.tsx
+++ b/frontend/openpoll/src/pages/dos/DosResult.tsx
@@ -19,43 +19,8 @@ import { Toast } from "@/components/molecules/toast/Toast";
 import { AdBanner } from "@/components/atoms/adBanner/AdBanner";
 import { useDosCardDownload } from "./hooks/useDosCardDownload";
 
-interface DetailsToggleProps {
-  detail: string[];
-  features: string[];
-  tags: string[];
-}
-
-function DetailsToggle({ detail, features, tags }: DetailsToggleProps) {
-  const [open, setOpen] = useState(false);
-  return (
-    <div style={{ marginTop: 32 }}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        style={{
-          width: "100%",
-          padding: "16px 20px",
-          background: "var(--color-surface)",
-          border: "1px solid var(--color-border)",
-          borderRadius: 12,
-          fontSize: 16,
-          fontWeight: 700,
-          color: "var(--color-foreground)",
-          cursor: "pointer",
-        }}
-      >
-        {open ? "접기" : "상세 설명 더 보기 ↓"}
-      </button>
-      {open && (
-        <div style={{ marginTop: 16 }}>
-          <DescriptionSection detail={detail} />
-          <CharacteristicsSection features={features} tags={tags} />
-          <NoticeSection />
-        </div>
-      )}
-    </div>
-  );
-}
+const OG_W = 1200;
+const OG_H = 630;
 
 export function DosResult() {
   usePageMeta("DOS 테스트 결과", "나의 정치 성향 분석 결과를 확인하세요.");
@@ -104,10 +69,12 @@ export function DosResult() {
   useEffect(() => {
     const el = cardWrapperRef.current;
     if (!el) return;
-    const observer = new ResizeObserver((entries) => {
-      const width = entries[0]?.contentRect.width;
-      if (width) setCardScale(width / 1080);
-    });
+    const update = () => {
+      const w = el.clientWidth;
+      if (w > 0) setCardScale(w / OG_W);
+    };
+    update();
+    const observer = new ResizeObserver(update);
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
@@ -135,10 +102,9 @@ export function DosResult() {
             style={{
               position: "relative",
               width: "100%",
-              maxWidth: 640,
-              margin: "0 auto",
-              height: 1080 * cardScale,
+              paddingTop: `${(OG_H / OG_W) * 100}%`,
               overflow: "hidden",
+              borderRadius: 24,
             }}
           >
             <div
@@ -146,8 +112,8 @@ export function DosResult() {
                 position: "absolute",
                 top: 0,
                 left: 0,
-                width: 1080,
-                height: 1080,
+                width: OG_W,
+                height: OG_H,
                 transform: `scale(${cardScale})`,
                 transformOrigin: "top left",
               }}
@@ -155,12 +121,18 @@ export function DosResult() {
               <DosResultCard
                 type={localResultData}
                 scores={cardScores}
-                variant="square"
+                variant="og"
               />
             </div>
           </div>
         )}
-        <DetailsToggle detail={detail} features={features} tags={tags} />
+
+        <div style={{ marginTop: 32 }}>
+          <DescriptionSection detail={detail} />
+          <CharacteristicsSection features={features} tags={tags} />
+          <NoticeSection />
+        </div>
+
         <AdBanner className="mb-8" />
         <ActionButtons onShare={() => setShowShareModal(true)} onImageSave={handleImageSave} />
         <NavigationLinks />
@@ -176,17 +148,15 @@ export function DosResult() {
         message={
           saveState === 'success'
             ? '결과 카드가 저장됐어요'
-            : saveState === 'error'
-              ? '저장에 실패했어요. 잠시 후 다시 시도해주세요.'
-              : '추후 구현될 기능입니다!'
+            : '저장에 실패했어요. 잠시 후 다시 시도해주세요.'
         }
-        type={saveState === 'error' ? 'error' : saveState === 'success' ? 'success' : 'info'}
+        type={saveState === 'error' ? 'error' : 'success'}
         isVisible={showToast}
         onClose={() => setShowToast(false)}
         contentStyle={{ backgroundColor: "#ffffff", color: "#1a1a1a" }}
       />
 
-      {/* 오프스크린 캡처 타깃: 1080x1080 원본 크기 */}
+      {/* 오프스크린 캡처 타깃: 1080x1080 원본 크기 (저장용) */}
       {localResultData && (
         <div
           style={{ position: 'fixed', left: -99999, top: 0, pointerEvents: 'none' }}

--- a/frontend/openpoll/src/pages/dos/DosResult.tsx
+++ b/frontend/openpoll/src/pages/dos/DosResult.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { usePageMeta } from "@/hooks/usePageMeta";
 import type { DosResult as DosResultData } from "@/types/api.types";
@@ -63,11 +63,10 @@ export function DosResult() {
     [localResultData]
   );
 
-  const cardWrapperRef = useRef<HTMLDivElement>(null);
   const [cardScale, setCardScale] = useState(1);
 
-  useEffect(() => {
-    const el = cardWrapperRef.current;
+  // 콜백 ref: isLoading 플립 후 실제로 DOM이 붙는 시점에 실행됨 (useRef+useEffect는 초기 렌더에 ref가 null이라 observer가 안 붙었음)
+  const cardWrapperRef = useCallback((el: HTMLDivElement | null) => {
     if (!el) return;
     const update = () => {
       const w = el.clientWidth;
@@ -102,7 +101,7 @@ export function DosResult() {
             style={{
               position: "relative",
               width: "100%",
-              paddingTop: `${(OG_H / OG_W) * 100}%`,
+              height: OG_H * cardScale,
               overflow: "hidden",
               borderRadius: 24,
             }}

--- a/frontend/openpoll/src/pages/dos/DosShare.tsx
+++ b/frontend/openpoll/src/pages/dos/DosShare.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef, useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { motion } from "motion/react";
 import { Brain, Home } from "lucide-react";
@@ -6,11 +6,11 @@ import { usePageMeta } from "@/hooks/usePageMeta";
 import { useStructuredData } from "@/hooks/useStructuredData";
 import { dosResultTypes } from "@/shared/constants/dosResultTypes";
 import {
-    ResultHeader,
     DescriptionSection,
     CharacteristicsSection,
     NoticeSection,
 } from "./components";
+import { DosResultCard } from "./components/DosResultCard";
 
 function NotFoundView() {
     return (
@@ -78,6 +78,20 @@ export function DosShare() {
         provider: { "@type": "Organization", name: "OpenPoll", url: "https://www.openpoll.co.kr" },
     } : null);
 
+    const cardWrapperRef = useRef<HTMLDivElement>(null);
+    const [cardScale, setCardScale] = useState(1);
+
+    useEffect(() => {
+        const el = cardWrapperRef.current;
+        if (!el) return;
+        const observer = new ResizeObserver((entries) => {
+            const width = entries[0]?.contentRect.width;
+            if (width) setCardScale(width / 1080);
+        });
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+
     if (!resultData) return <NotFoundView />;
 
     const { detail = [], features = [], tag: tags = [] } = resultData;
@@ -98,11 +112,31 @@ export function DosShare() {
                     </div>
                 </motion.div>
 
-                <ResultHeader
-                    type={type || ""}
-                    name={resultData.name}
-                    description={resultData.description}
-                />
+                <div
+                    ref={cardWrapperRef}
+                    style={{
+                        position: "relative",
+                        width: "100%",
+                        maxWidth: 640,
+                        margin: "0 auto 32px",
+                        height: 1080 * cardScale,
+                        overflow: "hidden",
+                    }}
+                >
+                    <div
+                        style={{
+                            position: "absolute",
+                            top: 0,
+                            left: 0,
+                            width: 1080,
+                            height: 1080,
+                            transform: `scale(${cardScale})`,
+                            transformOrigin: "top left",
+                        }}
+                    >
+                        <DosResultCard type={resultData} variant="square" showCTA />
+                    </div>
+                </div>
 
                 <DescriptionSection detail={detail} />
                 <CharacteristicsSection features={features} tags={tags} />

--- a/frontend/openpoll/src/pages/dos/components/DosResultCard.tsx
+++ b/frontend/openpoll/src/pages/dos/components/DosResultCard.tsx
@@ -21,6 +21,7 @@ const SIZE = {
 
 export function DosResultCard({ type, scores, variant, showCTA }: Props) {
   const { w, h } = SIZE[variant]
+  const isOg = variant === 'og'
   return (
     <div
       style={{
@@ -30,7 +31,7 @@ export function DosResultCard({ type, scores, variant, showCTA }: Props) {
         fontFamily: "'Pretendard Variable', Pretendard, sans-serif",
         background: '#FFF9E6',
         color: '#1a1a1a',
-        borderRadius: 24,
+        borderRadius: isOg ? 24 : 0,
         overflow: 'hidden',
       }}
     >
@@ -50,20 +51,39 @@ function renderLeft(type: DosResultTypeData, variant: 'square' | 'og') {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
-        padding: isOg ? 40 : 60,
+        padding: isOg ? '32px 24px' : '48px 40px',
         color: 'white',
-        gap: isOg ? 12 : 24,
       }}
     >
-      <div style={{ fontSize: isOg ? 220 : 360, lineHeight: 1 }}>
+      {/* 이모지: 상단~중앙 영역을 flex:1 로 차지해 시각적으로 중앙 정렬 */}
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          fontSize: isOg ? 240 : 380,
+          lineHeight: 1,
+        }}
+      >
         {type.animal.emoji}
       </div>
-      <div style={{ fontSize: isOg ? 72 : 100, fontWeight: 900, letterSpacing: -4, lineHeight: 1 }}>
-        {type.id}
-      </div>
-      <div style={{ fontSize: isOg ? 22 : 28, opacity: 0.9, fontWeight: 700 }}>
-        {type.animal.name}
+      {/* CMFD + 사자: 하단 */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: isOg ? 4 : 10,
+        }}
+      >
+        <div style={{ fontSize: isOg ? 56 : 88, fontWeight: 900, letterSpacing: -3, lineHeight: 1 }}>
+          {type.id}
+        </div>
+        <div style={{ fontSize: isOg ? 18 : 26, opacity: 0.9, fontWeight: 700 }}>
+          {type.animal.name}
+        </div>
       </div>
     </div>
   )
@@ -81,19 +101,20 @@ function renderRight(
     <div
       style={{
         flex: 1,
+        minWidth: 0,
         display: 'flex',
         flexDirection: 'column',
-        padding: isOg ? 40 : 60,
-        gap: isOg ? 14 : 24,
+        padding: isOg ? '48px 52px' : '64px 60px',
+        gap: isOg ? 26 : 34,
         background: '#FFF9E6',
       }}
     >
-      <div style={{ fontSize: isOg ? 14 : 20, fontWeight: 700, letterSpacing: 4, color: '#666' }}>
+      <div style={{ fontSize: isOg ? 16 : 22, fontWeight: 700, letterSpacing: 4, color: '#666' }}>
         나의 DOS 유형
       </div>
       <div
         style={{
-          fontSize: isOg ? 38 : 56,
+          fontSize: isOg ? 44 : 60,
           fontWeight: 900,
           lineHeight: 1.1,
           letterSpacing: -2,
@@ -103,12 +124,14 @@ function renderRight(
       </div>
       <div
         style={{
-          fontSize: isOg ? 18 : 24,
+          alignSelf: 'flex-start',
+          maxWidth: '100%',
+          fontSize: isOg ? 20 : 26,
           fontWeight: 600,
-          padding: isOg ? '10px 14px' : '16px 20px',
+          padding: isOg ? '11px 18px' : '14px 20px',
           background: 'white',
           border: '2px solid #1a1a1a',
-          borderRadius: 12,
+          borderRadius: 14,
           color: '#333',
         }}
       >
@@ -116,6 +139,19 @@ function renderRight(
       </div>
       {scores && renderAxes(scores, type.color, isOg)}
       {keywords.length > 0 && renderKeywords(keywords, type.color, isOg)}
+      {!isOg && type.description && (
+        <div
+          style={{
+            fontSize: 22,
+            lineHeight: 1.55,
+            color: '#444',
+            fontWeight: 500,
+            wordBreak: 'keep-all',
+          }}
+        >
+          {type.description}
+        </div>
+      )}
       <div
         style={{
           marginTop: 'auto',
@@ -124,17 +160,17 @@ function renderRight(
           alignItems: 'center',
         }}
       >
-        <span style={{ fontSize: isOg ? 13 : 16, fontWeight: 800, letterSpacing: 3, color: '#666' }}>
+        <span style={{ fontSize: isOg ? 15 : 18, fontWeight: 800, letterSpacing: 3, color: '#666' }}>
           OPENPOLL.CO.KR
         </span>
         {showCTA && (
           <span
             style={{
-              fontSize: isOg ? 14 : 18,
+              fontSize: isOg ? 16 : 20,
               fontWeight: 800,
               background: '#1a1a1a',
               color: 'white',
-              padding: isOg ? '6px 12px' : '8px 16px',
+              padding: isOg ? '8px 14px' : '8px 16px',
               borderRadius: 100,
             }}
           >
@@ -154,27 +190,28 @@ function renderAxes(scores: DosCardScores, accent: string, isOg: boolean) {
     { label: '개발', value: scores.development },
   ]
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: isOg ? 6 : 12 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: isOg ? 12 : 14 }}>
       {items.map((it) => (
         <div
           key={it.label}
           style={{
             display: 'grid',
-            gridTemplateColumns: isOg ? '46px 1fr 46px' : '60px 1fr 60px',
-            gap: isOg ? 10 : 12,
+            gridTemplateColumns: isOg ? '52px minmax(0, 1fr) 56px' : '60px minmax(0, 1fr) 60px',
+            gap: isOg ? 14 : 14,
             alignItems: 'center',
           }}
         >
-          <span style={{ fontSize: isOg ? 14 : 18, fontWeight: 700, color: '#1a1a1a' }}>{it.label}</span>
-          <div style={{ height: isOg ? 8 : 12, background: '#E5E1D6', borderRadius: 100, overflow: 'hidden' }}>
+          <span style={{ fontSize: isOg ? 18 : 20, fontWeight: 700, color: '#1a1a1a' }}>{it.label}</span>
+          <div style={{ height: isOg ? 14 : 16, background: '#E5E1D6', borderRadius: 100, overflow: 'hidden' }}>
             <div style={{ height: '100%', width: `${it.value}%`, background: accent, borderRadius: 100 }} />
           </div>
           <span
             style={{
-              fontSize: isOg ? 14 : 18,
+              fontSize: isOg ? 16 : 18,
               fontWeight: 700,
               color: '#666',
               textAlign: 'right',
+              whiteSpace: 'nowrap',
             }}
           >
             {Math.round(it.value)}%
@@ -187,17 +224,17 @@ function renderAxes(scores: DosCardScores, accent: string, isOg: boolean) {
 
 function renderKeywords(keywords: string[], accent: string, isOg: boolean) {
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: isOg ? 6 : 8 }}>
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: isOg ? 10 : 8 }}>
       {keywords.map((kw) => (
         <span
           key={kw}
           style={{
-            fontSize: isOg ? 13 : 16,
+            fontSize: isOg ? 16 : 18,
             fontWeight: 700,
             color: accent,
             background: 'white',
-            border: `1.5px solid ${accent}`,
-            padding: isOg ? '4px 10px' : '6px 14px',
+            border: `2px solid ${accent}`,
+            padding: isOg ? '7px 14px' : '6px 14px',
             borderRadius: 100,
           }}
         >

--- a/frontend/openpoll/src/pages/dos/components/DosResultCard.tsx
+++ b/frontend/openpoll/src/pages/dos/components/DosResultCard.tsx
@@ -1,0 +1,160 @@
+import type { DosResultTypeData } from '@/shared/constants/dosResultTypes'
+
+export interface DosCardScores {
+  change: number        // 0-100
+  distribution: number
+  rights: number
+  development: number
+}
+
+interface Props {
+  type: DosResultTypeData
+  scores?: DosCardScores
+  variant: 'square' | 'og'
+  showCTA?: boolean
+}
+
+const SIZE = {
+  square: { w: 1080, h: 1080 },
+  og:     { w: 1200, h: 630  },
+}
+
+export function DosResultCard({ type, scores, variant, showCTA }: Props) {
+  const { w, h } = SIZE[variant]
+  const showScores = variant === 'square' && !!scores
+  return (
+    <div
+      style={{
+        width: w,
+        height: h,
+        display: 'flex',
+        fontFamily: "'Pretendard Variable', Pretendard, sans-serif",
+        background: '#FFF9E6',
+        color: '#1a1a1a',
+        borderRadius: variant === 'og' ? 0 : 24,
+        overflow: 'hidden',
+      }}
+    >
+      {renderLeft(type, variant)}
+      {renderRight(type, scores, showScores, showCTA)}
+    </div>
+  )
+}
+
+function renderLeft(type: DosResultTypeData, variant: 'square' | 'og') {
+  const isOg = variant === 'og'
+  return (
+    <div
+      style={{
+        flex: isOg ? '0 0 40%' : '0 0 45%',
+        background: type.color,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: isOg ? 48 : 60,
+        color: 'white',
+        gap: isOg ? 16 : 24,
+      }}
+    >
+      <div style={{ fontSize: isOg ? 280 : 360, lineHeight: 1 }}>
+        {type.animal.emoji}
+      </div>
+      <div style={{ fontSize: isOg ? 80 : 100, fontWeight: 900, letterSpacing: -4, lineHeight: 1 }}>
+        {type.id}
+      </div>
+      <div style={{ fontSize: isOg ? 22 : 28, opacity: 0.9, fontWeight: 700 }}>
+        {type.animal.name}
+      </div>
+    </div>
+  )
+}
+
+function renderRight(
+  type: DosResultTypeData,
+  scores: DosCardScores | undefined,
+  showScores: boolean,
+  showCTA: boolean | undefined,
+) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 60,
+        gap: 24,
+        background: '#FFF9E6',
+      }}
+    >
+      <div style={{ fontSize: 20, fontWeight: 700, letterSpacing: 4, color: '#666' }}>
+        나의 DOS 유형
+      </div>
+      <div style={{ fontSize: 56, fontWeight: 900, lineHeight: 1.1, letterSpacing: -2 }}>
+        {type.name}
+      </div>
+      <div
+        style={{
+          fontSize: 24,
+          fontWeight: 600,
+          padding: '16px 20px',
+          background: 'white',
+          border: '2px solid #1a1a1a',
+          borderRadius: 12,
+          color: '#333',
+        }}
+      >
+        "{type.tagline}"
+      </div>
+      {showScores && scores && renderAxes(scores, type.color)}
+      <div
+        style={{
+          marginTop: 'auto',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <span style={{ fontSize: 16, fontWeight: 800, letterSpacing: 3, color: '#666' }}>
+          OPENPOLL.CO.KR
+        </span>
+        {showCTA && (
+          <span
+            style={{
+              fontSize: 18,
+              fontWeight: 800,
+              background: '#1a1a1a',
+              color: 'white',
+              padding: '8px 16px',
+              borderRadius: 100,
+            }}
+          >
+            나도 테스트 →
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function renderAxes(scores: DosCardScores, accent: string) {
+  const items = [
+    { label: '변화', value: scores.change },
+    { label: '경쟁', value: scores.distribution },
+    { label: '자유', value: scores.rights },
+    { label: '개발', value: scores.development },
+  ]
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {items.map((it) => (
+        <div key={it.label} style={{ display: 'grid', gridTemplateColumns: '60px 1fr 60px', gap: 12, alignItems: 'center' }}>
+          <span style={{ fontSize: 18, fontWeight: 700, color: '#1a1a1a' }}>{it.label}</span>
+          <div style={{ height: 12, background: '#E5E1D6', borderRadius: 100, overflow: 'hidden' }}>
+            <div style={{ height: '100%', width: `${it.value}%`, background: accent, borderRadius: 100 }} />
+          </div>
+          <span style={{ fontSize: 18, fontWeight: 700, color: '#666', textAlign: 'right' }}>{Math.round(it.value)}%</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/openpoll/src/pages/dos/components/DosResultCard.tsx
+++ b/frontend/openpoll/src/pages/dos/components/DosResultCard.tsx
@@ -1,7 +1,7 @@
 import type { DosResultTypeData } from '@/shared/constants/dosResultTypes'
 
 export interface DosCardScores {
-  change: number        // 0-100
+  change: number
   distribution: number
   rights: number
   development: number
@@ -21,7 +21,6 @@ const SIZE = {
 
 export function DosResultCard({ type, scores, variant, showCTA }: Props) {
   const { w, h } = SIZE[variant]
-  const showScores = variant === 'square' && !!scores
   return (
     <div
       style={{
@@ -31,12 +30,12 @@ export function DosResultCard({ type, scores, variant, showCTA }: Props) {
         fontFamily: "'Pretendard Variable', Pretendard, sans-serif",
         background: '#FFF9E6',
         color: '#1a1a1a',
-        borderRadius: variant === 'og' ? 0 : 24,
+        borderRadius: 24,
         overflow: 'hidden',
       }}
     >
       {renderLeft(type, variant)}
-      {renderRight(type, scores, showScores, showCTA)}
+      {renderRight(type, scores, variant, showCTA)}
     </div>
   )
 }
@@ -52,15 +51,15 @@ function renderLeft(type: DosResultTypeData, variant: 'square' | 'og') {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        padding: isOg ? 48 : 60,
+        padding: isOg ? 40 : 60,
         color: 'white',
-        gap: isOg ? 16 : 24,
+        gap: isOg ? 12 : 24,
       }}
     >
-      <div style={{ fontSize: isOg ? 280 : 360, lineHeight: 1 }}>
+      <div style={{ fontSize: isOg ? 220 : 360, lineHeight: 1 }}>
         {type.animal.emoji}
       </div>
-      <div style={{ fontSize: isOg ? 80 : 100, fontWeight: 900, letterSpacing: -4, lineHeight: 1 }}>
+      <div style={{ fontSize: isOg ? 72 : 100, fontWeight: 900, letterSpacing: -4, lineHeight: 1 }}>
         {type.id}
       </div>
       <div style={{ fontSize: isOg ? 22 : 28, opacity: 0.9, fontWeight: 700 }}>
@@ -73,31 +72,40 @@ function renderLeft(type: DosResultTypeData, variant: 'square' | 'og') {
 function renderRight(
   type: DosResultTypeData,
   scores: DosCardScores | undefined,
-  showScores: boolean,
+  variant: 'square' | 'og',
   showCTA: boolean | undefined,
 ) {
+  const isOg = variant === 'og'
+  const keywords = type.tag.slice(0, 3)
   return (
     <div
       style={{
         flex: 1,
         display: 'flex',
         flexDirection: 'column',
-        padding: 60,
-        gap: 24,
+        padding: isOg ? 40 : 60,
+        gap: isOg ? 14 : 24,
         background: '#FFF9E6',
       }}
     >
-      <div style={{ fontSize: 20, fontWeight: 700, letterSpacing: 4, color: '#666' }}>
+      <div style={{ fontSize: isOg ? 14 : 20, fontWeight: 700, letterSpacing: 4, color: '#666' }}>
         나의 DOS 유형
       </div>
-      <div style={{ fontSize: 56, fontWeight: 900, lineHeight: 1.1, letterSpacing: -2 }}>
+      <div
+        style={{
+          fontSize: isOg ? 38 : 56,
+          fontWeight: 900,
+          lineHeight: 1.1,
+          letterSpacing: -2,
+        }}
+      >
         {type.name}
       </div>
       <div
         style={{
-          fontSize: 24,
+          fontSize: isOg ? 18 : 24,
           fontWeight: 600,
-          padding: '16px 20px',
+          padding: isOg ? '10px 14px' : '16px 20px',
           background: 'white',
           border: '2px solid #1a1a1a',
           borderRadius: 12,
@@ -106,7 +114,8 @@ function renderRight(
       >
         "{type.tagline}"
       </div>
-      {showScores && scores && renderAxes(scores, type.color)}
+      {scores && renderAxes(scores, type.color, isOg)}
+      {keywords.length > 0 && renderKeywords(keywords, type.color, isOg)}
       <div
         style={{
           marginTop: 'auto',
@@ -115,17 +124,17 @@ function renderRight(
           alignItems: 'center',
         }}
       >
-        <span style={{ fontSize: 16, fontWeight: 800, letterSpacing: 3, color: '#666' }}>
+        <span style={{ fontSize: isOg ? 13 : 16, fontWeight: 800, letterSpacing: 3, color: '#666' }}>
           OPENPOLL.CO.KR
         </span>
         {showCTA && (
           <span
             style={{
-              fontSize: 18,
+              fontSize: isOg ? 14 : 18,
               fontWeight: 800,
               background: '#1a1a1a',
               color: 'white',
-              padding: '8px 16px',
+              padding: isOg ? '6px 12px' : '8px 16px',
               borderRadius: 100,
             }}
           >
@@ -137,7 +146,7 @@ function renderRight(
   )
 }
 
-function renderAxes(scores: DosCardScores, accent: string) {
+function renderAxes(scores: DosCardScores, accent: string, isOg: boolean) {
   const items = [
     { label: '변화', value: scores.change },
     { label: '경쟁', value: scores.distribution },
@@ -145,15 +154,55 @@ function renderAxes(scores: DosCardScores, accent: string) {
     { label: '개발', value: scores.development },
   ]
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: isOg ? 6 : 12 }}>
       {items.map((it) => (
-        <div key={it.label} style={{ display: 'grid', gridTemplateColumns: '60px 1fr 60px', gap: 12, alignItems: 'center' }}>
-          <span style={{ fontSize: 18, fontWeight: 700, color: '#1a1a1a' }}>{it.label}</span>
-          <div style={{ height: 12, background: '#E5E1D6', borderRadius: 100, overflow: 'hidden' }}>
+        <div
+          key={it.label}
+          style={{
+            display: 'grid',
+            gridTemplateColumns: isOg ? '46px 1fr 46px' : '60px 1fr 60px',
+            gap: isOg ? 10 : 12,
+            alignItems: 'center',
+          }}
+        >
+          <span style={{ fontSize: isOg ? 14 : 18, fontWeight: 700, color: '#1a1a1a' }}>{it.label}</span>
+          <div style={{ height: isOg ? 8 : 12, background: '#E5E1D6', borderRadius: 100, overflow: 'hidden' }}>
             <div style={{ height: '100%', width: `${it.value}%`, background: accent, borderRadius: 100 }} />
           </div>
-          <span style={{ fontSize: 18, fontWeight: 700, color: '#666', textAlign: 'right' }}>{Math.round(it.value)}%</span>
+          <span
+            style={{
+              fontSize: isOg ? 14 : 18,
+              fontWeight: 700,
+              color: '#666',
+              textAlign: 'right',
+            }}
+          >
+            {Math.round(it.value)}%
+          </span>
         </div>
+      ))}
+    </div>
+  )
+}
+
+function renderKeywords(keywords: string[], accent: string, isOg: boolean) {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: isOg ? 6 : 8 }}>
+      {keywords.map((kw) => (
+        <span
+          key={kw}
+          style={{
+            fontSize: isOg ? 13 : 16,
+            fontWeight: 700,
+            color: accent,
+            background: 'white',
+            border: `1.5px solid ${accent}`,
+            padding: isOg ? '4px 10px' : '6px 14px',
+            borderRadius: 100,
+          }}
+        >
+          #{kw}
+        </span>
       ))}
     </div>
   )

--- a/frontend/openpoll/src/pages/dos/components/ShareModal.tsx
+++ b/frontend/openpoll/src/pages/dos/components/ShareModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
-import { X, Link2, Check, Copy, QrCode } from "lucide-react";
+import { X, Check, Copy } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { QRCodeSVG } from "qrcode.react";
 import { useTheme } from "@/contexts/ThemeContext";
@@ -15,30 +15,29 @@ interface SocialItem {
     label: string;
     icon: ReactNode;
     bgStyle: React.CSSProperties;
-    bgClass?: string;
     onClick: () => void;
 }
 
 const TwitterIcon = () => (
-    <svg className="w-8 h-8 text-white" viewBox="0 0 24 24" fill="currentColor">
+    <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor" style={{ color: 'white' }}>
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
     </svg>
 );
 
 const FacebookIcon = () => (
-    <svg className="w-8 h-8 text-white" viewBox="0 0 24 24" fill="currentColor">
+    <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor" style={{ color: 'white' }}>
         <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
     </svg>
 );
 
 const InstagramIcon = () => (
-    <svg className="w-8 h-8 text-white" viewBox="0 0 24 24" fill="currentColor">
+    <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor" style={{ color: 'white' }}>
         <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z" />
     </svg>
 );
 
 const EmailIcon = () => (
-    <svg className="w-8 h-8 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'white' }}>
         <rect x="2" y="4" width="20" height="16" rx="2" />
         <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
     </svg>
@@ -48,21 +47,19 @@ const SHARE_TEXT = "나의 DOS 정치 성향 결과를 확인해보세요!";
 const COPY_RESET_MS = 2500;
 const POPUP_OPTIONS = "width=550,height=420";
 
-const ICON_BASE_CLASS =
-    "w-16 h-16 rounded-full flex items-center justify-center transition-all";
-
 const openPopup = (url: string) => window.open(url, "_blank", POPUP_OPTIONS);
+
+const FONT_STACK = "'Pretendard Variable', Pretendard, sans-serif";
 
 export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
     const { isDark } = useTheme();
     const [copied, setCopied] = useState(false);
     const [emailCopied, setEmailCopied] = useState(false);
-    const [showQR, setShowQR] = useState(false);
+    const [hoverClose, setHoverClose] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
 
     const shareUrl = `${window.location.origin}/dos/share/${type}`;
 
-    // Reset states when modal closes
     useEffect(() => {
         if (!isOpen) {
             setCopied(false);
@@ -70,7 +67,6 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
         }
     }, [isOpen]);
 
-    // ESC key to close
     useEffect(() => {
         if (!isOpen) return;
         const handleEsc = (e: KeyboardEvent) => {
@@ -111,18 +107,19 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
         emailTimer.current = window.setTimeout(() => setEmailCopied(false), COPY_RESET_MS);
     }, [shareUrl]);
 
-    // Social share configuration
-    const twitterBgClass = `${ICON_BASE_CLASS} ${isDark ? 'bg-black border border-white/20 group-hover:border-white/40' : 'bg-gray-800 border border-gray-600 group-hover:border-gray-400'}`;
-    const defaultBgClass = `${ICON_BASE_CLASS} group-hover:brightness-110`;
-    const emailBgColor = emailCopied ? "#22c55e" : isDark ? "#555" : "#6b7280";
+    // 색상 토큰
+    const fg = isDark ? '#ffffff' : '#1a1a1a';
+    const bg = isDark ? '#1a1a1a' : '#ffffff';
+    const mutedFg = isDark ? '#a0a0a0' : '#666';
+    const hoverBg = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)';
+    const border2 = `2px solid ${fg}`;
 
     const socialItems: SocialItem[] = [
         {
             id: "twitter",
             label: "X",
             icon: <TwitterIcon />,
-            bgStyle: {},
-            bgClass: twitterBgClass,
+            bgStyle: { backgroundColor: '#0f0f0f' },
             onClick: () =>
                 openPopup(
                     `https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(SHARE_TEXT)}`
@@ -133,7 +130,6 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
             label: "Facebook",
             icon: <FacebookIcon />,
             bgStyle: { backgroundColor: "#1877F2" },
-            bgClass: defaultBgClass,
             onClick: () =>
                 openPopup(
                     `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`
@@ -147,25 +143,28 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
                 background:
                     "radial-gradient(circle at 30% 107%, #fdf497 0%, #fdf497 5%, #fd5949 45%, #d6249f 60%, #285AEB 90%)",
             },
-            bgClass: defaultBgClass,
             onClick: async () => {
-                await navigator.clipboard.writeText(shareUrl);
+                try { await navigator.clipboard.writeText(shareUrl); } catch { /* noop */ }
                 window.open("https://www.instagram.com/", "_blank");
             },
         },
         {
             id: "email",
-            label: emailCopied ? "링크 복사됨!" : "이메일",
+            label: emailCopied ? "복사됨!" : "이메일",
             icon: <EmailIcon />,
-            bgStyle: { backgroundColor: emailBgColor },
-            bgClass: defaultBgClass,
+            bgStyle: { backgroundColor: emailCopied ? "#22c55e" : "#6b7280" },
             onClick: handleEmailShare,
         },
     ];
 
-    const borderClass = isDark ? 'border-white/10' : 'border-black/10';
-    const mutedTextClass = isDark ? 'text-gray-400' : 'text-gray-500';
-    const labelTextClass = isDark ? 'text-gray-300' : 'text-gray-600';
+    const sectionLabelStyle: React.CSSProperties = {
+        fontSize: 11,
+        fontWeight: 800,
+        letterSpacing: 3,
+        color: mutedFg,
+        marginBottom: 12,
+        textTransform: 'uppercase',
+    };
 
     return (
         <AnimatePresence>
@@ -180,59 +179,131 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
                     aria-modal="true"
                     aria-label="결과 공유하기"
                     onClick={onClose}
+                    style={{ fontFamily: FONT_STACK }}
                 >
                     {/* Backdrop */}
-                    <div className="absolute inset-0 bg-black/50" aria-hidden="true" style={{ backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', overscrollBehavior: 'contain' }} />
+                    <div
+                        className="absolute inset-0"
+                        aria-hidden="true"
+                        style={{
+                            backgroundColor: 'rgba(0,0,0,0.55)',
+                            backdropFilter: 'blur(10px)',
+                            WebkitBackdropFilter: 'blur(10px)',
+                            overscrollBehavior: 'contain',
+                        }}
+                    />
 
                     {/* Modal */}
                     <motion.div
                         initial={{ opacity: 0, scale: 0.95, y: 20 }}
                         animate={{ opacity: 1, scale: 1, y: 0 }}
                         exit={{ opacity: 0, scale: 0.95, y: 20 }}
-                        transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
-                        className={`relative max-w-lg rounded-2xl border ${borderClass} shadow-2xl`}
-                        style={{ backgroundColor: isDark ? "#1a1a2e" : "#ffffff", width: "85%" }}
+                        transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
+                        className="relative"
+                        style={{
+                            backgroundColor: bg,
+                            color: fg,
+                            border: border2,
+                            borderRadius: 20,
+                            width: '92%',
+                            maxWidth: 500,
+                            boxShadow: isDark
+                                ? '0 20px 60px rgba(0,0,0,0.6)'
+                                : '0 20px 60px rgba(0,0,0,0.18)',
+                            overflow: 'hidden',
+                        }}
                         onClick={(e) => e.stopPropagation()}
                     >
                         {/* Header */}
-                        <div className={`flex items-center justify-between p-5 border-b ${borderClass}`}>
-                            <div className="flex items-center gap-3">
-                                <div className={`w-10 h-10 bg-gradient-to-br from-blue-500/20 to-purple-500/20 border ${isDark ? 'border-white/20' : 'border-black/20'} rounded-xl flex items-center justify-center`}>
-                                    <Link2 className={`w-5 h-5 ${isDark ? 'text-white' : 'text-black'}`} />
-                                </div>
-                                <div className={`text-lg font-bold ${isDark ? 'text-white' : 'text-black'}`}>
-                                    결과 공유하기
-                                </div>
+                        <div style={{ padding: '26px 28px 18px', position: 'relative' }}>
+                            <div
+                                style={{
+                                    fontSize: 11,
+                                    fontWeight: 800,
+                                    letterSpacing: 4,
+                                    color: mutedFg,
+                                    marginBottom: 6,
+                                }}
+                            >
+                                SHARE
+                            </div>
+                            <div
+                                style={{
+                                    fontSize: 26,
+                                    fontWeight: 900,
+                                    letterSpacing: -1,
+                                    lineHeight: 1.1,
+                                    color: fg,
+                                }}
+                            >
+                                결과 공유하기
                             </div>
                             <button
                                 onClick={onClose}
                                 aria-label="닫기"
-                                className={`p-2 rounded-lg ${isDark ? 'hover:bg-white/10' : 'hover:bg-black/10'} transition-colors`}
+                                onMouseEnter={() => setHoverClose(true)}
+                                onMouseLeave={() => setHoverClose(false)}
+                                style={{
+                                    position: 'absolute',
+                                    top: 20,
+                                    right: 20,
+                                    padding: 8,
+                                    borderRadius: 10,
+                                    background: hoverClose ? hoverBg : 'transparent',
+                                    color: fg,
+                                    transition: 'background-color 0.15s ease',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                }}
                             >
-                                <X className={`w-5 h-5 ${isDark ? 'text-white' : 'text-black'}`} />
+                                <X size={20} />
                             </button>
                         </div>
 
-                        <div className={`p-5 border-b ${borderClass}`}>
-                            <div className={`text-sm ${labelTextClass} font-semibold mb-4`}>
-                                공유
-                            </div>
-                            <div className="flex items-start justify-around">
+                        {/* 공유 아이콘 */}
+                        <div style={{ padding: '0 28px 24px' }}>
+                            <div style={{ display: 'flex', justifyContent: 'space-around', alignItems: 'flex-start' }}>
                                 {/* eslint-disable-next-line react-hooks/refs -- onClick handlers only access refs on click, not during render */}
                                 {socialItems.map((item) => (
                                     <button
                                         key={item.id}
                                         onClick={item.onClick}
                                         aria-label={`${item.label}로 공유`}
-                                        className="flex-1 flex flex-col items-center gap-2 group"
+                                        style={{
+                                            display: 'flex',
+                                            flexDirection: 'column',
+                                            alignItems: 'center',
+                                            gap: 8,
+                                            background: 'transparent',
+                                            border: 'none',
+                                            cursor: 'pointer',
+                                            flex: 1,
+                                        }}
                                     >
                                         <div
-                                            className={item.bgClass}
-                                            style={item.bgStyle}
+                                            style={{
+                                                width: 56,
+                                                height: 56,
+                                                borderRadius: '50%',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                justifyContent: 'center',
+                                                transition: 'filter 0.15s ease, transform 0.15s ease',
+                                                ...item.bgStyle,
+                                            }}
+                                            onMouseEnter={(e) => {
+                                                e.currentTarget.style.filter = 'brightness(1.08)';
+                                                e.currentTarget.style.transform = 'translateY(-2px)';
+                                            }}
+                                            onMouseLeave={(e) => {
+                                                e.currentTarget.style.filter = 'none';
+                                                e.currentTarget.style.transform = 'translateY(0)';
+                                            }}
                                         >
                                             {item.icon}
                                         </div>
-                                        <span className={`text-[11px] ${mutedTextClass}`}>
+                                        <span style={{ fontSize: 12, fontWeight: 600, color: mutedFg }}>
                                             {item.label}
                                         </span>
                                     </button>
@@ -240,96 +311,95 @@ export function ShareModal({ isOpen, onClose, type }: ShareModalProps) {
                             </div>
                         </div>
 
-                        <div className="p-5 space-y-4">
-                            <div>
-                                <div className={`text-sm ${labelTextClass} font-semibold mb-2`}>
-                                    공유 링크
-                                </div>
-                                <div className="flex items-center gap-2">
-                                    <input
-                                        ref={inputRef}
-                                        id="share-url-input"
-                                        name="share-url"
-                                        type="text"
-                                        readOnly
-                                        value={shareUrl}
-                                        className={`flex-1 px-4 py-3 ${isDark ? 'bg-white/5 border-white/10 text-white' : 'bg-black/5 border-black/10 text-black'} border rounded-xl text-sm focus:outline-none`}
-                                        style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}
-                                    />
-                                    <button
-                                        onClick={handleCopy}
-                                        className={`flex items-center gap-2 px-4 py-3 rounded-xl font-semibold text-sm transition-all duration-200 whitespace-nowrap ${copied
-                                            ? "bg-green-500/20 text-green-400 border border-green-500/30"
-                                            : isDark ? "bg-white text-black hover:bg-gray-200" : "bg-black text-white hover:bg-gray-800"
-                                            }`}
-                                    >
-                                        {copied ? (
-                                            <>
-                                                <Check className="w-4 h-4" />
-                                                <span>복사됨!</span>
-                                            </>
-                                        ) : (
-                                            <>
-                                                <Copy className="w-4 h-4" />
-                                                <span>복사</span>
-                                            </>
-                                        )}
-                                    </button>
-                                </div>
+                        {/* 공유 링크 */}
+                        <div style={{ padding: '0 28px 20px' }}>
+                            <div style={sectionLabelStyle}>공유 링크</div>
+                            <div style={{ display: 'flex', gap: 10 }}>
+                                <input
+                                    ref={inputRef}
+                                    id="share-url-input"
+                                    name="share-url"
+                                    type="text"
+                                    readOnly
+                                    value={shareUrl}
+                                    style={{
+                                        flex: 1,
+                                        minWidth: 0,
+                                        padding: '12px 16px',
+                                        border: border2,
+                                        borderRadius: 14,
+                                        backgroundColor: bg,
+                                        color: fg,
+                                        fontSize: 14,
+                                        fontWeight: 500,
+                                        textOverflow: 'ellipsis',
+                                        overflow: 'hidden',
+                                        outline: 'none',
+                                        fontFamily: FONT_STACK,
+                                    }}
+                                />
+                                <button
+                                    onClick={handleCopy}
+                                    style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: 6,
+                                        padding: '10px 20px',
+                                        borderRadius: 100,
+                                        background: copied ? '#22c55e' : fg,
+                                        color: copied ? '#ffffff' : bg,
+                                        border: 'none',
+                                        fontWeight: 800,
+                                        fontSize: 14,
+                                        whiteSpace: 'nowrap',
+                                        cursor: 'pointer',
+                                        transition: 'transform 0.12s ease',
+                                        fontFamily: FONT_STACK,
+                                    }}
+                                    onMouseEnter={(e) => { e.currentTarget.style.transform = 'translateY(-1px)'; }}
+                                    onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)'; }}
+                                >
+                                    {copied ? (
+                                        <>
+                                            <Check size={16} />
+                                            <span>복사됨!</span>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Copy size={16} />
+                                            <span>복사</span>
+                                        </>
+                                    )}
+                                </button>
                             </div>
                         </div>
 
-                        <div className="px-5 pb-5">
-                            <button
-                                onClick={() => setShowQR(!showQR)}
-                                className={`flex items-center gap-2 text-sm ${mutedTextClass} ${isDark ? 'hover:text-white' : 'hover:text-black'} transition-colors`}
+                        {/* QR 코드 */}
+                        <div style={{ padding: '0 28px 28px' }}>
+                            <div style={sectionLabelStyle}>QR 코드</div>
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    alignItems: 'center',
+                                    gap: 10,
+                                    padding: 20,
+                                    border: border2,
+                                    borderRadius: 14,
+                                    background: '#ffffff',
+                                }}
                             >
-                                <QrCode className="w-4 h-4" />
-                                <span>
-                                    {showQR
-                                        ? "QR 코드 숨기기"
-                                        : "QR 코드 보기"}
-                                </span>
-                            </button>
-                            <AnimatePresence>
-                                {showQR && (
-                                    <motion.div
-                                        initial={{ height: 0, opacity: 0 }}
-                                        animate={{
-                                            height: "auto",
-                                            opacity: 1,
-                                        }}
-                                        exit={{ height: 0, opacity: 0 }}
-                                        transition={{ duration: 0.2 }}
-                                        className="overflow-hidden"
-                                    >
-                                        <div className="flex flex-col items-center gap-3 pt-4">
-                                            <div className="bg-white p-3 rounded-xl">
-                                                <QRCodeSVG
-                                                    value={shareUrl}
-                                                    size={160}
-                                                    bgColor="#ffffff"
-                                                    fgColor="#000000"
-                                                    level="M"
-                                                />
-                                            </div>
-                                            <p className="text-xs text-gray-500">
-                                                QR 코드를 스캔하여 결과를
-                                                공유하세요
-                                            </p>
-                                        </div>
-                                    </motion.div>
-                                )}
-                            </AnimatePresence>
-                        </div>
-
-                        <div className={`p-5 border-t ${borderClass} flex justify-end`}>
-                            <button
-                                onClick={onClose}
-                                className={`px-4 py-2 rounded-lg border ${isDark ? 'border-white/10 text-gray-300 hover:text-white hover:border-white/20' : 'border-black/10 text-gray-600 hover:text-black hover:border-black/20'} transition-colors`}
-                            >
-                                닫기
-                            </button>
+                                <QRCodeSVG
+                                    value={shareUrl}
+                                    size={148}
+                                    bgColor="#ffffff"
+                                    fgColor="#1a1a1a"
+                                    level="M"
+                                />
+                                <p style={{ fontSize: 13, fontWeight: 600, color: '#666', margin: 0 }}>
+                                    QR 코드를 스캔해 결과를 공유하세요
+                                </p>
+                            </div>
                         </div>
                     </motion.div>
                 </motion.div>

--- a/frontend/openpoll/src/pages/dos/hooks/useDosCardDownload.ts
+++ b/frontend/openpoll/src/pages/dos/hooks/useDosCardDownload.ts
@@ -1,0 +1,24 @@
+import { toPng } from 'html-to-image'
+import { useCallback } from 'react'
+
+export function useDosCardDownload() {
+  return useCallback(async (el: HTMLElement | null, typeId: string) => {
+    if (!el) return
+    try {
+      const dataUrl = await toPng(el, {
+        width: 1080,
+        height: 1080,
+        pixelRatio: 2,
+        cacheBust: true,
+        backgroundColor: '#FFF9E6',
+      })
+      const link = document.createElement('a')
+      link.download = `openpoll-dos-${typeId}.png`
+      link.href = dataUrl
+      link.click()
+    } catch (err) {
+      console.error('[useDosCardDownload] 저장 실패:', err)
+      throw err
+    }
+  }, [])
+}

--- a/frontend/openpoll/src/shared/constants/dosResultTypes.ts
+++ b/frontend/openpoll/src/shared/constants/dosResultTypes.ts
@@ -5,6 +5,9 @@ export interface DosResultTypeData {
   detail: string[];
   features: string[];
   tag: string[];
+  animal: { emoji: string; name: string };
+  color: string;
+  tagline: string;
 }
 
 export const dosResultTypes: DosResultTypeData[] = [
@@ -22,7 +25,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '기술/산업 혁신에 낙관적',
       '빠른 변화와 도전을 두려워하지 않음'
     ],
-    tag: ['자유시장', '규제완화', '스타트업', '기술혁신', '기업가정신', '성과주의']
+    tag: ['자유시장', '규제완화', '스타트업', '기술혁신', '기업가정신', '성과주의'],
+    animal: { emoji: '🦁', name: '사자' },
+    color: '#FF7A59',
+    tagline: '변화 속에서 기회를 포착하는 불꽃',
   },
   {
     id: 'CMFN',
@@ -38,7 +44,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '윤리적 비즈니스와 기술에 관심',
       '극단적 성장 모델에 회의적'
     ],
-    tag: ['지속가능성', 'ESG', '윤리적기술', '그린테크', '장기성장', '책임있는 자유']
+    tag: ['지속가능성', 'ESG', '윤리적기술', '그린테크', '장기성장', '책임있는 자유'],
+    animal: { emoji: '🦋', name: '나비' },
+    color: '#4ADE80',
+    tagline: '자유롭게 변화하는 생태의 수호자',
   },
   {
     id: 'CMOD',
@@ -54,7 +63,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '불안정한 변화에 대한 경계',
       '조직적/전략적 접근 선호'
     ],
-    tag: ['제도개혁', '국가전략', '성과관리', '산업정책', '규제설계', '거버넌스']
+    tag: ['제도개혁', '국가전략', '성과관리', '산업정책', '규제설계', '거버넌스'],
+    animal: { emoji: '🐺', name: '늑대' },
+    color: '#8B5CF6',
+    tagline: '조직된 힘으로 세상을 바꾸는 전략가',
   },
   {
     id: 'CMON',
@@ -70,7 +82,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '장기 리스크를 신중히 검토',
       '급진적 실험에 회의적'
     ],
-    tag: ['점진적개혁', '사회안정', '중장기전략', '제도보완', '리스크관리']
+    tag: ['점진적개혁', '사회안정', '중장기전략', '제도보완', '리스크관리'],
+    animal: { emoji: '🦉', name: '올빼미' },
+    color: '#0EA5E9',
+    tagline: '변화 속에서 균형을 찾는 현자',
   },
   {
     id: 'CEFD',
@@ -86,7 +101,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '사회 운동/공공 담론에 적극적',
       '도덕적 분노가 행동으로 이어짐'
     ],
-    tag: ['사회정의', '불평등해소', '재분배', '기본소득', '노동권', '인권']
+    tag: ['사회정의', '불평등해소', '재분배', '기본소득', '노동권', '인권'],
+    animal: { emoji: '🐝', name: '벌' },
+    color: '#F59E0B',
+    tagline: '연대로 움직이는 진보의 일꾼',
   },
   {
     id: 'CEFN',
@@ -102,7 +120,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '강요보다 공감과 설득 선호',
       '온건하지만 일관된 가치관'
     ],
-    tag: ['공정경제', '지속가능사회', '윤리적 소비', '사회적 책임', '공동체']
+    tag: ['공정경제', '지속가능사회', '윤리적 소비', '사회적 책임', '공동체'],
+    animal: { emoji: '🦦', name: '수달' },
+    color: '#65A30D',
+    tagline: '함께 살아가는 자연의 친구',
   },
   {
     id: 'CEOD',
@@ -118,7 +139,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '조직적 문제 해결 능력',
       '국가 역할을 중요하게 인식'
     ],
-    tag: ['복지국가', '공공정책', '제도개혁', '사회안정망', '교육개혁', '의료공공성']
+    tag: ['복지국가', '공공정책', '제도개혁', '사회안정망', '교육개혁', '의료공공성'],
+    animal: { emoji: '🐘', name: '코끼리' },
+    color: '#EC4899',
+    tagline: '공동체를 이끄는 든든한 기둥',
   },
   {
     id: 'CEON',
@@ -134,7 +158,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '공동체 책임 의식 강함',
       '가치 간 충돌에 민감'
     ],
-    tag: ['장기복지 전략', '구조개혁', '사회통합', '공공채임', '세대정의']
+    tag: ['장기복지 전략', '구조개혁', '사회통합', '공공채임', '세대정의'],
+    animal: { emoji: '🐳', name: '고래' },
+    color: '#0D9488',
+    tagline: '깊고 넓은 연대의 바다',
   },
   {
     id: 'SMFD',
@@ -150,7 +177,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '실질적 성과를 중시',
       '급격한 변화에 회의적'
     ],
-    tag: ['자기책임', '시장경제', '세금효율', '경제안정']
+    tag: ['자기책임', '시장경제', '세금효율', '경제안정'],
+    animal: { emoji: '🦅', name: '독수리' },
+    color: '#D97706',
+    tagline: '높은 곳에서 기회를 노리는 개척자',
   },
   {
     id: 'SMFN',
@@ -166,7 +196,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '이념보다 실용 중시',
       '중도적 성향'
     ],
-    tag: ['지속가능성', '기술해결책', '중도정치', '생활정책', '현실개혁']
+    tag: ['지속가능성', '기술해결책', '중도정치', '생활정책', '현실개혁'],
+    animal: { emoji: '🦌', name: '사슴' },
+    color: '#16A34A',
+    tagline: '숲을 지키는 조용한 수호자',
   },
   {
     id: 'SMOD',
@@ -182,7 +215,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '조직과 국가 안정 중시',
       '리더십 지향적'
     ],
-    tag: ['법과 질서', '국가안정', '경제성장', '조직관리', '전통가치']
+    tag: ['법과 질서', '국가안정', '경제성장', '조직관리', '전통가치'],
+    animal: { emoji: '🐅', name: '호랑이' },
+    color: '#6366F1',
+    tagline: '당당한 원칙의 수호자',
   },
   {
     id: 'SMON',
@@ -198,7 +234,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '점진적 변화 선호',
       '조정자/중재자 성향'
     ],
-    tag: ['중도', '사회안정', '점진개혁', '합리적 정책', '리스크 회피']
+    tag: ['중도', '사회안정', '점진개혁', '합리적 정책', '리스크 회피'],
+    animal: { emoji: '🐢', name: '거북이' },
+    color: '#64748B',
+    tagline: '신중하게 지켜내는 균형의 달인',
   },
   {
     id: 'SEFD',
@@ -214,7 +253,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '공감 능력과 실천성 겸비',
       '개혁적이지만 온건함'
     ],
-    tag: ['사회안전망', '공정기회', '교육평등', '보건의료', '현실복지']
+    tag: ['사회안전망', '공정기회', '교육평등', '보건의료', '현실복지'],
+    animal: { emoji: '🐬', name: '돌고래' },
+    color: '#DC2626',
+    tagline: '따뜻한 연대의 항해자',
   },
   {
     id: 'SEFN',
@@ -230,7 +272,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '극단 회피 성향',
       '중재자 역할 수행'
     ],
-    tag: ['포용사회', '사회적합의', '지속가능정책', '공존', '갈등조정']
+    tag: ['포용사회', '사회적합의', '지속가능정책', '공존', '갈등조정'],
+    animal: { emoji: '🐑', name: '양' },
+    color: '#059669',
+    tagline: '평화로운 공동체의 일원',
   },
   {
     id: 'SEOD',
@@ -246,7 +291,10 @@ export const dosResultTypes: DosResultTypeData[] = [
       '정책 중심 문제 해결',
       '정책 설계/추진에 강점'
     ],
-    tag: ['복지정책', '제도설계', '공공시스템', '사회통합', '정책리더십']
+    tag: ['복지정책', '제도설계', '공공시스템', '사회통합', '정책리더십'],
+    animal: { emoji: '🐻', name: '곰' },
+    color: '#A855F7',
+    tagline: '든든하게 함께 걷는 동반자',
   },
   {
     id: 'SEON',
@@ -262,6 +310,9 @@ export const dosResultTypes: DosResultTypeData[] = [
       '취약 계층 보호 인식 강함',
       '실행보단 검토 우선'
     ],
-    tag: ['장기사회전략', '사회안정망', '지속가능복지', '공공책임', '점진적 개혁']
+    tag: ['장기사회전략', '사회안정망', '지속가능복지', '공공책임', '점진적 개혁'],
+    animal: { emoji: '🐼', name: '판다' },
+    color: '#78716C',
+    tagline: '자연과 함께하는 평온의 상징',
   }
 ];


### PR DESCRIPTION
## Summary


<img width="2160" height="2160" alt="openpoll-dos-SEON" src="https://github.com/user-attachments/assets/8685e9f6-c6a9-45cb-a909-d11eb986cedc" />

DOS 테스트 결과 화면 전반을 리디자인하고, 결과를 카드 이미지로 공유할 수 있는 파이프라인 구축.

### 결과 카드 컴포넌트
- `DosResultCard` 신규 추가 (square 1080×1080 / og 1200×630 두 variant)
- 왼쪽 패널: 동물 이모지 + 유형 ID(CMFD 등) + 동물명
- 오른쪽 패널: 유형명 / 태그라인 박스 / 4축 바 그래프(퍼센트 표기) / 키워드 pill / OPENPOLL.CO.KR
- square variant에는 키워드 아래 한 줄 요약 description 포함, 저장용으로 `borderRadius: 0`

### 결과 페이지 개편
- 상단 히어로를 1200×630 가로형 결과 카드로 교체 (기존 정사각 1080 → OG 비율)
- padding-top 트릭 + ResizeObserver 로 반응형 스케일링
- 상세 설명은 토글 없이 바로 노출

### 이미지 저장 & OG 공유 파이프라인
- `useDosCardDownload` 훅: html-to-image로 square 카드 PNG 저장
- `og-generator.mjs`: satori + resvg-js 로 빌드 타임에 16유형 × 2 variant = 32장 PNG 생성
- `seo-prerender.mjs`: 공유 페이지에 유형별 `og:image` 메타 주입
- build 스크립트에 위 두 스텝 연결 (`vite build && og-generator && seo-prerender`)

### 결과 공유 모달 리디자인
- 결과 카드 디자인 DNA 적용: 검정 2px border, 20px 라운드, pill 복사 버튼, tagline 박스 스타일 input
- 구조 단순화: 섹션 구분선·맨 아래 닫기 버튼·QR 토글 제거. QR 기본 노출
- 다크 모드 토큰 기반(fg/bg/border)으로 반전

### 버그 수정
- **카드 스케일링 미적용 버그 수정**: `isLoading=true` 초기 렌더에서 wrapper ref가 null이라 ResizeObserver가 붙지 않던 문제. `useRef + useEffect` → React 19 콜백 ref로 전환하여 DOM 마운트 시점에 observer 부착

## Test plan

- [x] `npm run typecheck` (tsc -b) 통과
- [x] `npm run lint` (eslint) 에러 0
- [x] `npm run build` — vite build + og-generator 32장 + seo-prerender 34페이지 모두 성공
- [x] 라이트/다크 모드 모두 Playwright로 렌더 검증 (결과 카드, 공유 모달)
- [ ] DOS 테스트 완주 → 실제 axisPercentages로 결과 화면 확인
- [ ] 이미지 저장 버튼 → PNG 다운로드 정상 여부
- [ ] 공유 모달: 복사 / QR / X·Facebook·Instagram·이메일 팝업 동작
- [ ] 16 유형 전수 확인 (긴 이름/tagline/description에서 오버플로우 없는지)
- [ ] 모바일 뷰포트에서 카드 스케일링 동작